### PR TITLE
Enable frontend pagination for PessoasList

### DIFF
--- a/frontend/src/views/pessoas/PessoasList.vue
+++ b/frontend/src/views/pessoas/PessoasList.vue
@@ -34,16 +34,10 @@ async function carregarPessoas() {
   error.value = null;
   try {
     const data = await funcionarioService.listar(filtros.value);
-    // Backend ListarTodos returns List<FuncionarioDTO>, no pagination meta info yet
-    // If backend implements pagination, we need to adapt.
-    // For now assuming it returns simple array.
-    if (Array.isArray(data)) {
-        pessoas.value = data;
-        totalPages.value = 1;
-    } else {
-        pessoas.value = data.content || data;
-        totalPages.value = data.totalPages || 1;
-    }
+
+    // Backend returns a paginated response (Page<FuncionarioDTO>)
+    pessoas.value = data.content || [];
+    totalPages.value = data.totalPages || 0;
   } catch (err) {
     console.error('Erro ao carregar pessoas:', err);
     error.value = err.message || "Erro ao carregar pessoas";


### PR DESCRIPTION
Updates `PessoasList.vue` to expect a Spring Data `Page` object (with `content` and `totalPages`) instead of checking for an array. This aligns the frontend with the existing `FuncionarioController` implementation which returns a paginated response.

Key changes:
- Removed `Array.isArray` check and legacy fallback logic.
- Directly mapped `data.content` to `pessoas` list.
- Directly mapped `data.totalPages` to pagination state.

---
*PR created automatically by Jules for task [9694882633591861491](https://jules.google.com/task/9694882633591861491) started by @diogo-rp-menezes*