### PR TITLE
⚡ Optimize UserContextService with Request Caching

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/service/UserContextService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/UserContextService.java
@@ -7,16 +7,20 @@ import br.com.aegispatrimonio.repository.FuncionarioRepository;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.annotation.RequestScope;
 
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
+@RequestScope
 public class UserContextService {
 
     private final CurrentUserProvider currentUserProvider;
     private final FuncionarioRepository funcionarioRepository;
+
+    private Funcionario cachedFuncionario;
 
     public UserContextService(CurrentUserProvider currentUserProvider, FuncionarioRepository funcionarioRepository) {
         this.currentUserProvider = currentUserProvider;
@@ -34,6 +38,10 @@ public class UserContextService {
 
     @Transactional(readOnly = true)
     public Funcionario getCurrentFuncionario() {
+        if (cachedFuncionario != null) {
+            return cachedFuncionario;
+        }
+
         Usuario usuario = getCurrentUser();
         Funcionario funcionarioPrincipal = usuario.getFuncionario();
 
@@ -42,8 +50,10 @@ public class UserContextService {
         }
 
         // Fetch fresh from DB to get Lazy collections
-        return funcionarioRepository.findByIdWithFiliais(funcionarioPrincipal.getId())
+        cachedFuncionario = funcionarioRepository.findByIdWithFiliais(funcionarioPrincipal.getId())
                 .orElseThrow(() -> new AccessDeniedException("Funcionário não encontrado."));
+
+        return cachedFuncionario;
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/br/com/aegispatrimonio/service/UserContextServicePerformanceTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/UserContextServicePerformanceTest.java
@@ -1,0 +1,94 @@
+package br.com.aegispatrimonio.service;
+
+import br.com.aegispatrimonio.BaseIT;
+import br.com.aegispatrimonio.model.*;
+import br.com.aegispatrimonio.repository.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.HashSet;
+
+import static org.mockito.Mockito.*;
+
+@Transactional
+class UserContextServicePerformanceTest extends BaseIT {
+
+    @Autowired
+    private UserContextService userContextService;
+
+    @MockBean
+    private CurrentUserProvider currentUserProvider;
+
+    @SpyBean
+    private FuncionarioRepository funcionarioRepository;
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private DepartamentoRepository departamentoRepository;
+
+    @Autowired
+    private FilialRepository filialRepository;
+
+    private Usuario testUser;
+    private Funcionario testFuncionario;
+
+    @BeforeEach
+    void setUp() {
+        // Mock Request Context
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(new MockHttpServletRequest()));
+
+        // Setup dependencies
+        Filial filial = new Filial();
+        filial.setNome("Headquarters");
+        filial.setCodigo("HQ001");
+        filial.setCnpj("12.345.678/0001-90");
+        filial.setEndereco("123 Main St");
+        filial.setTipo(TipoFilial.MATRIZ);
+        filialRepository.save(filial);
+
+        Departamento dep = new Departamento();
+        dep.setNome("IT");
+        dep.setFilial(filial);
+        departamentoRepository.save(dep);
+
+        testFuncionario = new Funcionario();
+        testFuncionario.setNome("John Doe");
+        testFuncionario.setMatricula("12345");
+        testFuncionario.setCargo("Developer");
+        testFuncionario.setDepartamento(dep);
+        testFuncionario.setFiliais(new HashSet<>());
+        testFuncionario.getFiliais().add(filial);
+        funcionarioRepository.save(testFuncionario);
+
+        testUser = new Usuario();
+        testUser.setEmail("john.doe@example.com");
+        testUser.setPassword("password");
+        testUser.setRole("ROLE_USER");
+        testUser.setStatus(Status.ATIVO);
+        testUser.setFuncionario(testFuncionario);
+        usuarioRepository.save(testUser);
+
+        when(currentUserProvider.getCurrentUsuario()).thenReturn(testUser);
+    }
+
+    @Test
+    void testGetCurrentFuncionarioPerformance() {
+        // First call
+        userContextService.getCurrentFuncionario();
+
+        // Second call
+        userContextService.getCurrentFuncionario();
+
+        // Expect findByIdWithFiliais to be called ONCE (after optimization)
+        verify(funcionarioRepository, times(1)).findByIdWithFiliais(testFuncionario.getId());
+    }
+}


### PR DESCRIPTION
`UserContextService.getCurrentFuncionario` was causing redundant database queries when called multiple times within a single request (e.g., via `getUserFiliais`).

This PR:
1.  Converts `UserContextService` to `@RequestScope`.
2.  Implements caching for the `Funcionario` entity within the request lifecycle.
3.  Ensures `findByIdWithFiliais` is called only once per request.

Performance:
- Confirmed by `UserContextServicePerformanceTest`: calls reduced from 2 to 1 for repeated invocations.
- Eliminates N+1 like behavior for logic that heavily relies on user context checks.

Test:
- Added regression test `UserContextServicePerformanceTest`.
- Ran full test suite.

---
*PR created automatically by Jules for task [14506135863036444953](https://jules.google.com/task/14506135863036444953) started by @diogo-rp-menezes*