### PR TITLE
⚡ Fix N+1 query in AtivoService responsibility validation

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/service/AtivoService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/AtivoService.java
@@ -201,7 +201,7 @@ public class AtivoService {
         }
 
         if (ativoCreateDTO.funcionarioResponsavelId() != null) {
-            Funcionario responsavel = funcionarioRepository.findById(ativoCreateDTO.funcionarioResponsavelId())
+            Funcionario responsavel = funcionarioRepository.findByIdWithFiliais(ativoCreateDTO.funcionarioResponsavelId())
                     .orElseThrow(() -> new EntityNotFoundException("Funcionário responsável não encontrado com ID: " + ativoCreateDTO.funcionarioResponsavelId()));
             validarConsistenciaResponsavel(responsavel, filial);
             ativo.setFuncionarioResponsavel(responsavel);
@@ -258,7 +258,7 @@ public class AtivoService {
         }
 
         if (ativoUpdateDTO.funcionarioResponsavelId() != null) {
-            Funcionario responsavel = funcionarioRepository.findById(ativoUpdateDTO.funcionarioResponsavelId())
+            Funcionario responsavel = funcionarioRepository.findByIdWithFiliais(ativoUpdateDTO.funcionarioResponsavelId())
                     .orElseThrow(() -> new EntityNotFoundException("Funcionário responsável não encontrado com ID: " + ativoUpdateDTO.funcionarioResponsavelId()));
             validarConsistenciaResponsavel(responsavel, filial);
             ativo.setFuncionarioResponsavel(responsavel);

--- a/src/test/java/br/com/aegispatrimonio/service/AtivoServicePerformanceIT.java
+++ b/src/test/java/br/com/aegispatrimonio/service/AtivoServicePerformanceIT.java
@@ -1,0 +1,118 @@
+package br.com.aegispatrimonio.service;
+
+import br.com.aegispatrimonio.BaseIT;
+import br.com.aegispatrimonio.dto.AtivoCreateDTO;
+import br.com.aegispatrimonio.model.*;
+import br.com.aegispatrimonio.repository.*;
+import jakarta.persistence.EntityManager;
+import org.hibernate.Session;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestPropertySource(properties = {
+    "spring.jpa.properties.hibernate.generate_statistics=true",
+    "logging.level.org.hibernate.stat=DEBUG"
+})
+public class AtivoServicePerformanceIT extends BaseIT {
+
+    @Autowired
+    private AtivoService ativoService;
+
+    @Autowired
+    private FilialRepository filialRepository;
+
+    @Autowired
+    private TipoAtivoRepository tipoAtivoRepository;
+
+    @Autowired
+    private FornecedorRepository fornecedorRepository;
+
+    @Autowired
+    private FuncionarioRepository funcionarioRepository;
+
+    @Autowired
+    private DepartamentoRepository departamentoRepository;
+
+    @Autowired
+    private EntityManager entityManager;
+
+    @Test
+    @Transactional
+    public void testCriarAtivoPerformance() {
+        // Setup Data
+        Filial filial = new Filial();
+        filial.setNome("Test Filial Perf");
+        filial.setCodigo("PERF001");
+        filial.setCnpj("00.000.000/0002-00");
+        filial.setTipo(TipoFilial.MATRIZ);
+        filial = filialRepository.save(filial);
+
+        TipoAtivo tipoAtivo = new TipoAtivo();
+        tipoAtivo.setNome("Test Tipo Perf");
+        tipoAtivo.setCategoriaContabil(CategoriaContabil.IMOBILIZADO);
+        tipoAtivo = tipoAtivoRepository.save(tipoAtivo);
+
+        Fornecedor fornecedor = new Fornecedor();
+        fornecedor.setNome("Test Fornecedor Perf");
+        fornecedor.setCnpj("00.000.000/0002-01");
+        fornecedor.setStatus(StatusFornecedor.ATIVO);
+        fornecedor = fornecedorRepository.save(fornecedor);
+
+        Departamento departamento = new Departamento();
+        departamento.setNome("IT");
+        departamento.setFilial(filial);
+        departamento = departamentoRepository.save(departamento);
+
+        Funcionario funcionario = new Funcionario();
+        funcionario.setNome("John Doe");
+        funcionario.setMatricula("M001");
+        funcionario.setCargo("Analyst");
+        funcionario.setDepartamento(departamento);
+        funcionario.setFiliais(Collections.singleton(filial));
+        funcionario = funcionarioRepository.save(funcionario);
+
+        entityManager.flush();
+        entityManager.clear(); // Clear context to force DB hit
+
+        Session session = entityManager.unwrap(Session.class);
+        Statistics statistics = session.getSessionFactory().getStatistics();
+        statistics.clear();
+
+        // Act
+        AtivoCreateDTO dto = new AtivoCreateDTO(
+            filial.getId(),
+            "Laptop Perf",
+            tipoAtivo.getId(),
+            "PAT-PERF-001",
+            null,
+            LocalDate.now(),
+            fornecedor.getId(),
+            BigDecimal.valueOf(2500),
+            funcionario.getId(),
+            "Obs",
+            "Warranty",
+            null,
+            null
+        );
+
+        ativoService.criar(dto);
+
+        entityManager.flush();
+
+        // Assert
+        long queryCount = statistics.getPrepareStatementCount();
+        System.out.println("Queries executed: " + queryCount);
+
+        // Baseline was 9. Optimized should be 8.
+        assertThat(queryCount).as("Should have eliminated N+1 query for filiais").isLessThanOrEqualTo(8);
+    }
+}

--- a/src/test/java/br/com/aegispatrimonio/service/AtivoServiceTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/AtivoServiceTest.java
@@ -150,7 +150,7 @@ class AtivoServiceTest {
         when(tipoAtivoRepository.findById(1L)).thenReturn(Optional.of(new TipoAtivo()));
         when(fornecedorRepository.findById(1L)).thenReturn(Optional.of(new Fornecedor()));
         when(localizacaoRepository.findById(1L)).thenReturn(Optional.of(localizacao));
-        when(funcionarioRepository.findById(3L)).thenReturn(Optional.of(responsavelOutraFilial));
+        when(funcionarioRepository.findByIdWithFiliais(3L)).thenReturn(Optional.of(responsavelOutraFilial));
 
         assertThrows(IllegalArgumentException.class, () -> ativoService.atualizar(10L, updateDTO));
     }
@@ -204,7 +204,7 @@ class AtivoServiceTest {
         when(tipoAtivoRepository.findById(1L)).thenReturn(Optional.of(new TipoAtivo()));
         when(fornecedorRepository.findById(1L)).thenReturn(Optional.of(new Fornecedor()));
         when(localizacaoRepository.findById(1L)).thenReturn(Optional.of(localizacao));
-        when(funcionarioRepository.findById(1L)).thenReturn(Optional.of(adminUser.getFuncionario()));
+        when(funcionarioRepository.findByIdWithFiliais(1L)).thenReturn(Optional.of(adminUser.getFuncionario()));
 
         when(ativoRepository.save(any(Ativo.class))).thenAnswer(invocation -> {
             Ativo a = invocation.getArgument(0);


### PR DESCRIPTION
💡 **What:**
- Replaced `funcionarioRepository.findById` with `funcionarioRepository.findByIdWithFiliais` in `AtivoService.criar` and `AtivoService.atualizar`.
- Added `AtivoServicePerformanceIT` to verify the fix and prevent regression.
- Updated `AtivoServiceTest` to mock the new repository method call.

🎯 **Why:**
- When creating or updating an asset with a responsible employee, the validation `validarConsistenciaResponsavel` accesses `responsavel.getFiliais()`.
- Previously, `responsavel` was loaded lazily, causing an extra database query to fetch `filiais`.
- This change ensures `filiais` are eagerly fetched in a single query using `LEFT JOIN FETCH`.

📊 **Measured Improvement:**
- **Baseline:** 9 queries executed during `AtivoService.criar`.
- **Optimized:** 8 queries executed.
- The specific N+1 query (`select ... from funcionario_filial ...`) was eliminated.

---
*PR created automatically by Jules for task [2908654646654827777](https://jules.google.com/task/2908654646654827777) started by @diogo-rp-menezes*