### PR TITLE
Enable Monolith Deployment with SPA Routing

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/config/SecurityConfig.java
+++ b/src/main/java/br/com/aegispatrimonio/config/SecurityConfig.java
@@ -63,11 +63,15 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(new AntPathRequestMatcher("/api/v1/auth/**")).permitAll()
+                        // Protected API
+                        .requestMatchers(new AntPathRequestMatcher("/api/**")).authenticated()
+                        // Public/System
                         .requestMatchers(new AntPathRequestMatcher("/swagger-ui/**")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/v3/api-docs/**")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/actuator/**")).permitAll()
                         .requestMatchers(new AntPathRequestMatcher("/error/**")).permitAll()
-                        .anyRequest().authenticated()
+                        // Allow everything else (SPA routing + Static Resources)
+                        .anyRequest().permitAll()
                 )
                 .authenticationProvider(authenticationProvider())
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/br/com/aegispatrimonio/config/SpaWebFilter.java
+++ b/src/main/java/br/com/aegispatrimonio/config/SpaWebFilter.java
@@ -1,0 +1,35 @@
+package br.com.aegispatrimonio.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+public class SpaWebFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        String path = request.getRequestURI();
+
+        // Forward non-API, non-static GET requests to index.html for SPA routing
+        if ("GET".equals(request.getMethod()) &&
+            !path.startsWith("/api") &&
+            !path.startsWith("/actuator") &&
+            !path.startsWith("/swagger-ui") &&
+            !path.startsWith("/v3/api-docs") &&
+            !path.contains(".") &&
+            !path.equals("/")) {
+
+            request.getRequestDispatcher("/index.html").forward(request, response);
+            return;
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/test/java/br/com/aegispatrimonio/config/SpaWebFilterTest.java
+++ b/src/test/java/br/com/aegispatrimonio/config/SpaWebFilterTest.java
@@ -1,0 +1,79 @@
+package br.com.aegispatrimonio.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.RequestDispatcher;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class SpaWebFilterTest {
+
+    @InjectMocks
+    private SpaWebFilter spaWebFilter;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain chain;
+
+    @Mock
+    private RequestDispatcher requestDispatcher;
+
+    @Test
+    void doFilterInternal_shouldForwardToIndex_whenPathIsSpaRoute() throws Exception {
+        when(request.getRequestURI()).thenReturn("/dashboard");
+        when(request.getMethod()).thenReturn("GET");
+        when(request.getRequestDispatcher("/index.html")).thenReturn(requestDispatcher);
+
+        spaWebFilter.doFilterInternal(request, response, chain);
+
+        verify(requestDispatcher).forward(request, response);
+        verify(chain, never()).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_shouldChain_whenPathIsApi() throws Exception {
+        when(request.getRequestURI()).thenReturn("/api/v1/ativos");
+        when(request.getMethod()).thenReturn("GET"); // Ensure path check causes the skip
+
+        spaWebFilter.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+        verify(request, never()).getRequestDispatcher(any());
+    }
+
+    @Test
+    void doFilterInternal_shouldChain_whenPathIsStaticFile() throws Exception {
+        when(request.getRequestURI()).thenReturn("/assets/style.css");
+        when(request.getMethod()).thenReturn("GET");
+
+        spaWebFilter.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+    }
+
+    @Test
+    void doFilterInternal_shouldChain_whenPathIsRoot() throws Exception {
+        when(request.getRequestURI()).thenReturn("/");
+        when(request.getMethod()).thenReturn("GET");
+
+        spaWebFilter.doFilterInternal(request, response, chain);
+
+        verify(chain).doFilter(request, response);
+    }
+}


### PR DESCRIPTION
This PR finalizes the Monolith deployment capability by ensuring the Spring Boot backend can correctly serve the Vue.js SPA.

**Changes:**
1.  **SPA Routing:** Added `SpaWebFilter` which intercepts requests. If the request is NOT an API call (`/api`, `/actuator`) and NOT a static file (no extension), it forwards to `/index.html`. This allows Vue Router's History Mode to work (e.g., refreshing `/dashboard` loads the app instead of 404).
2.  **Security Configuration:** Updated `SecurityConfig` to adopt a "Secure API, Permit Public" strategy.
    - `/api/**` is now strictly authenticated.
    - `anyRequest()` is permitted to allow access to SPA routes and static assets without login (the SPA handles login redirection).
3.  **Testing:** Added `SpaWebFilterTest` to verify forwarding logic. Ran full suite to ensure no regressions.

**Impact:**
- The Docker image (`aegispatrimonio:latest`) now serves the full application (Backend + Frontend) on port 8080.
- Users can access the application via browser and navigate deep links.

---
*PR created automatically by Jules for task [4086958307089752968](https://jules.google.com/task/4086958307089752968) started by @diogo-rp-menezes*