### PR TITLE
Fix flaky integration tests and build stability

### DIFF
--- a/src/test/java/br/com/aegispatrimonio/integration/UserContextServicePerformanceIT.java
+++ b/src/test/java/br/com/aegispatrimonio/integration/UserContextServicePerformanceIT.java
@@ -8,11 +8,15 @@ import br.com.aegispatrimonio.service.UserContextService;
 import jakarta.persistence.EntityManager;
 import org.hibernate.Session;
 import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 import java.util.Set;
 
@@ -47,6 +51,10 @@ public class UserContextServicePerformanceIT extends BaseIT {
 
     @BeforeEach
     void setUp() {
+        // Setup Request Context for @RequestScope bean
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
+
         // Create Filial
         Filial filial = new Filial();
         filial.setNome("Matriz Teste");
@@ -86,6 +94,11 @@ public class UserContextServicePerformanceIT extends BaseIT {
 
         entityManager.flush();
         entityManager.clear();
+    }
+
+    @AfterEach
+    void tearDown() {
+        RequestContextHolder.resetRequestAttributes();
     }
 
     @Test


### PR DESCRIPTION
This PR addresses critical P0/P2 issues blocking the MVP validation:
1.  **Fixed `UserContextServicePerformanceIT`**: The test was failing with `ScopeNotActiveException` because `UserContextService` is `@RequestScope` and integration tests do not automatically provide a request context. I added manual setup/teardown of `MockHttpServletRequest`.
2.  **Stabilized Build**: Investigated and resolved test pollution issues that were causing `AtivoControllerWriteSecurityIT` and `SeedDataIT` to fail intermittently or in full runs. Confirmed that adding `@DirtiesContext` caused cascading failures due to database schema dropping issues with H2, so the solution focused on fixing the root cause in `UserContextServicePerformanceIT`.

The build is now stable and all tests pass.

---
*PR created automatically by Jules for task [4584363967987941722](https://jules.google.com/task/4584363967987941722) started by @diogo-rp-menezes*