### PR TITLE
Enable Mobile Access via Deep-Link QR Codes

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -60,3 +60,6 @@ spring.security.oauth2.client.provider.google.user-name-attribute=sub
 
 # Frontend Redirect URI after successful OAuth2 login
 app.oauth2.authorized-redirect-uris=${OAUTH2_REDIRECT_URIS:http://localhost:5173/login}
+
+# Frontend Base URL for links (e.g. QR Codes)
+app.frontend-url=${APP_FRONTEND_URL:http://localhost:5173}

--- a/src/test/java/br/com/aegispatrimonio/service/RelatorioServiceTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/RelatorioServiceTest.java
@@ -5,11 +5,9 @@ import br.com.aegispatrimonio.model.AtivoDetalheHardware;
 import br.com.aegispatrimonio.model.Funcionario;
 import br.com.aegispatrimonio.model.TipoAtivo;
 import br.com.aegispatrimonio.repository.AtivoRepository;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -28,17 +26,17 @@ class RelatorioServiceTest {
     @Mock
     private QRCodeService qrCodeService;
 
-    @Mock
-    private ObjectMapper objectMapper;
-
-    @InjectMocks
     private RelatorioService relatorioService;
 
     private Ativo ativo;
     private Funcionario funcionario;
+    private final String FRONTEND_URL = "http://test-frontend";
 
     @BeforeEach
     void setUp() {
+        // Manual instantiation to inject scalar value
+        relatorioService = new RelatorioService(ativoRepository, qrCodeService, FRONTEND_URL);
+
         funcionario = new Funcionario();
         funcionario.setNome("João da Silva");
 
@@ -56,6 +54,19 @@ class RelatorioServiceTest {
         AtivoDetalheHardware hardware = new AtivoDetalheHardware();
         hardware.setComputerName("NB-JOAO");
         ativo.setDetalheHardware(hardware);
+    }
+
+    @Test
+    void testGerarQrCode_Sucesso() {
+        when(ativoRepository.existsById(1L)).thenReturn(true);
+        when(qrCodeService.generateQRCode(anyString(), anyInt(), anyInt())).thenReturn(new byte[]{1, 2, 3});
+
+        byte[] result = relatorioService.gerarQrCode(1L);
+
+        assertNotNull(result);
+        verify(ativoRepository).existsById(1L);
+        // Verify the URL format
+        verify(qrCodeService).generateQRCode(eq(FRONTEND_URL + "/ativos/1"), eq(300), eq(300));
     }
 
     @Test


### PR DESCRIPTION
Updated `RelatorioService` to generate QR codes containing a URL pointing to the asset's detail page on the frontend (e.g., `http://localhost:5173/ativos/123`), replacing the previous JSON blob implementation. Added `app.frontend-url` to `application.properties` to support this. This change facilitates the "Phygital" link for mobile users scanning asset tags.

---
*PR created automatically by Jules for task [13032529893755004243](https://jules.google.com/task/13032529893755004243) started by @diogo-rp-menezes*