### PR TITLE
Extend depreciation methods with 150% Declining Balance

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/model/MetodoDepreciacao.java
+++ b/src/main/java/br/com/aegispatrimonio/model/MetodoDepreciacao.java
@@ -3,6 +3,7 @@ package br.com.aegispatrimonio.model;
 public enum MetodoDepreciacao {
     LINEAR, 
     ACELERADA,
-    SALDO_DECRESCENTE
+    SALDO_DECRESCENTE,
+    SALDO_DECRESCENTE_150
     // Pode adicionar outros métodos se necessário
 }

--- a/src/main/java/br/com/aegispatrimonio/service/DepreciacaoService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/DepreciacaoService.java
@@ -195,6 +195,20 @@ public class DepreciacaoService {
             return valorDepreciavel.multiply(fatorDecaimento).multiply(taxa);
         }
 
+        if (ativo.getMetodoDepreciacao() == MetodoDepreciacao.SALDO_DECRESCENTE_150) {
+            long vidaUtil = ativo.getVidaUtilMeses();
+            long mesesDecorridos = ChronoUnit.MONTHS.between(ativo.getDataInicioDepreciacao(), dataCalculo);
+
+            if (mesesDecorridos < 0 || mesesDecorridos >= vidaUtil) {
+                return BigDecimal.ZERO;
+            }
+
+            BigDecimal taxa = BigDecimal.valueOf(1.5).divide(BigDecimal.valueOf(vidaUtil), 10, RoundingMode.HALF_UP);
+            BigDecimal fatorDecaimento = BigDecimal.ONE.subtract(taxa).pow((int) mesesDecorridos);
+
+            return valorDepreciavel.multiply(fatorDecaimento).multiply(taxa);
+        }
+
         // Padrão: MetodoDepreciacao.LINEAR
         return valorDepreciavel.divide(BigDecimal.valueOf(ativo.getVidaUtilMeses()), 10, RoundingMode.HALF_UP);
     }

--- a/src/test/java/br/com/aegispatrimonio/service/DepreciacaoServiceTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/DepreciacaoServiceTest.java
@@ -146,4 +146,26 @@ class DepreciacaoServiceTest {
 
         assertEquals(0, depreciacaoEsperada.compareTo(valorCalculado.setScale(2, RoundingMode.HALF_UP)));
     }
+
+    @Test
+    @DisplayName("Deve calcular depreciação saldo decrescente 150% corretamente")
+    void calcularDepreciacaoMensal_comMetodoSaldoDecrescente150_deveCalcularCorretamente() {
+        ativo.setMetodoDepreciacao(MetodoDepreciacao.SALDO_DECRESCENTE_150);
+        ativo.setVidaUtilMeses(10);
+        ativo.setDataInicioDepreciacao(LocalDate.now().minusMonths(2));
+        when(ativoRepository.findById(1L)).thenReturn(Optional.of(ativo));
+
+        // --- Cálculo da depreciação esperada para validação ---
+        // Valor depreciável = 12000 - 2000 = 10000
+        // Vida útil = 10 meses. Taxa = 1.5 / 10 = 0.15
+        // Meses decorridos = 2
+        // Fator decaimento = (1 - 0.15)^2 = 0.85^2 = 0.7225
+        // Depreciação = 10000 * 0.7225 * 0.15 = 1083.75
+        BigDecimal depreciacaoEsperada = new BigDecimal("1083.75");
+
+        // --- Execução e Validação ---
+        BigDecimal valorCalculado = depreciacaoService.calcularDepreciacaoMensal(1L);
+
+        assertEquals(0, depreciacaoEsperada.compareTo(valorCalculado.setScale(2, RoundingMode.HALF_UP)));
+    }
 }

--- a/src/test/java/br/com/aegispatrimonio/service/impl/PermissionServiceImplTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/impl/PermissionServiceImplTest.java
@@ -16,6 +16,8 @@ import org.mockito.quality.Strictness;
 import org.springframework.security.core.Authentication;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 


### PR DESCRIPTION
Extended depreciation methods to include 150% Declining Balance (`SALDO_DECRESCENTE_150`). Implemented the calculation logic in `DepreciacaoService` and added unit tests. Also fixed a compilation error in `PermissionServiceImplTest.java` discovered during testing.

---
*PR created automatically by Jules for task [3601764783543224103](https://jules.google.com/task/3601764783543224103) started by @diogo-rp-menezes*