### PR TITLE
⚡ Optimize Role permissions fetching to eliminate N+1 queries

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/model/Role.java
+++ b/src/main/java/br/com/aegispatrimonio/model/Role.java
@@ -27,7 +27,7 @@ public class Role {
     @Column(length = 255)
     private String description;
 
-    @ManyToMany(fetch = FetchType.EAGER)
+    @ManyToMany(fetch = FetchType.LAZY)
     @JoinTable(
         name = "rbac_role_permission",
         joinColumns = @JoinColumn(name = "role_id"),

--- a/src/main/java/br/com/aegispatrimonio/repository/RoleRepository.java
+++ b/src/main/java/br/com/aegispatrimonio/repository/RoleRepository.java
@@ -2,8 +2,10 @@ package br.com.aegispatrimonio.repository;
 
 import br.com.aegispatrimonio.model.Role;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -12,4 +14,7 @@ import java.util.Optional;
 @Repository
 public interface RoleRepository extends JpaRepository<Role, Long> {
     Optional<Role> findByName(String name);
+
+    @Query("SELECT DISTINCT r FROM Role r LEFT JOIN FETCH r.permissions")
+    List<Role> findAllWithPermissions();
 }

--- a/src/main/java/br/com/aegispatrimonio/service/RbacManagementService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/RbacManagementService.java
@@ -32,7 +32,7 @@ public class RbacManagementService {
 
     @Transactional(readOnly = true)
     public List<RoleDTO> listarRoles() {
-        return roleRepository.findAll().stream()
+        return roleRepository.findAllWithPermissions().stream()
                 .map(rbacMapper::toRoleDTO)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/br/com/aegispatrimonio/service/RbacPerformanceTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/RbacPerformanceTest.java
@@ -1,0 +1,111 @@
+package br.com.aegispatrimonio.service;
+
+import br.com.aegispatrimonio.BaseIT;
+import br.com.aegispatrimonio.model.Permission;
+import br.com.aegispatrimonio.model.Role;
+import br.com.aegispatrimonio.repository.PermissionRepository;
+import br.com.aegispatrimonio.repository.RoleRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.hibernate.stat.Statistics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@Transactional
+public class RbacPerformanceTest extends BaseIT {
+
+    @Autowired
+    private RoleRepository roleRepository;
+
+    @Autowired
+    private PermissionRepository permissionRepository;
+
+    @Autowired
+    private RbacManagementService rbacManagementService;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    private Long roleId;
+
+    @BeforeEach
+    public void setup() {
+        permissionRepository.deleteAll();
+        roleRepository.deleteAll();
+
+        Permission p1 = new Permission();
+        p1.setResource("RES1");
+        p1.setAction("ACT1");
+        permissionRepository.save(p1);
+
+        Permission p2 = new Permission();
+        p2.setResource("RES2");
+        p2.setAction("ACT2");
+        permissionRepository.save(p2);
+
+        Role role = new Role();
+        role.setName("TEST_ROLE");
+        role.setDescription("Test Role");
+        role.setPermissions(new HashSet<>(Set.of(p1, p2)));
+        role = roleRepository.save(role);
+        roleId = role.getId();
+
+        entityManager.flush();
+        entityManager.clear();
+    }
+
+    @Test
+    @Transactional
+    public void testFetchBehavior() {
+        Session session = entityManager.unwrap(Session.class);
+        Statistics stats = session.getSessionFactory().getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        // 1. Fetch Role.
+        System.out.println("Fetching Role...");
+        Role fetchedRole = roleRepository.findById(roleId).orElseThrow();
+
+        long queryCountAfterFind = stats.getPrepareStatementCount();
+        System.out.println("Queries after findById: " + queryCountAfterFind);
+
+        // 2. Access permissions
+        System.out.println("Accessing Permissions...");
+        int permCount = fetchedRole.getPermissions().size();
+
+        long queryCountAfterAccess = stats.getPrepareStatementCount();
+        System.out.println("Queries after accessing permissions: " + queryCountAfterAccess);
+    }
+
+    @Test
+    public void testListarRolesPerformance() {
+        // Create another role to make N > 1
+        Role role2 = new Role();
+        role2.setName("TEST_ROLE_2");
+        role2.setDescription("Test Role 2");
+        roleRepository.save(role2);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Session session = entityManager.unwrap(Session.class);
+        Statistics stats = session.getSessionFactory().getStatistics();
+        stats.setStatisticsEnabled(true);
+        stats.clear();
+
+        System.out.println("Listing Roles...");
+        rbacManagementService.listarRoles();
+
+        long queryCount = stats.getPrepareStatementCount();
+        System.out.println("Queries during listarRoles: " + queryCount);
+        assertEquals(1, queryCount, "listarRoles should only execute 1 query (N+1 problem check)");
+    }
+}


### PR DESCRIPTION
💡 **What:**
- Changed `@ManyToMany` fetch type in `Role.java` from `EAGER` to `LAZY`.
- Implemented `findAllWithPermissions()` in `RoleRepository` using `LEFT JOIN FETCH` to eagerly load permissions in a single query.
- Updated `RbacManagementService.listarRoles()` to use the new repository method.
- Added `RbacPerformanceTest` to prevent regression.

🎯 **Why:**
- The `EAGER` fetch type on `Role.permissions` caused unnecessary database load when fetching roles where permissions were not needed (e.g., login flows looking up user roles).
- Paradoxically, `EAGER` fetch often leads to N+1 select issues when using `findAll()` (selecting all roles, then selecting permissions for each).
- This change ensures permissions are loaded lazily by default, but eagerly (and efficiently via Join) when explicitly required (e.g., RBAC administration).

📊 **Measured Improvement:**
- **`listarRoles`**: Reduced from **N+1 queries** (3 in baseline test) to **1 query**.
- **`findById` (Role)**: Reduced initial load from **1 join** to **1 simple select**. Permissions are loaded only on demand (total 2 queries if accessed), which optimizes flows where permissions are ignored.

---
*PR created automatically by Jules for task [16804426516238557362](https://jules.google.com/task/16804426516238557362) started by @diogo-rp-menezes*