### PR TITLE
feat: Autonomous Maintenance Dispatcher (Innovation Task)

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/repository/ManutencaoRepository.java
+++ b/src/main/java/br/com/aegispatrimonio/repository/ManutencaoRepository.java
@@ -1,6 +1,7 @@
 package br.com.aegispatrimonio.repository;
 
 import br.com.aegispatrimonio.model.Manutencao;
+import br.com.aegispatrimonio.model.StatusManutencao;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -9,12 +10,15 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.Optional;
 
 @Repository
 public interface ManutencaoRepository extends JpaRepository<Manutencao, Long>, JpaSpecificationExecutor<Manutencao> {
 
     boolean existsByAtivoId(Long ativoId);
+
+    boolean existsByAtivoIdAndStatusIn(Long ativoId, Collection<StatusManutencao> statuses);
 
     @Override
     @EntityGraph(attributePaths = {"ativo", "solicitante", "fornecedor", "tecnicoResponsavel"})

--- a/src/main/java/br/com/aegispatrimonio/service/HealthCheckService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/HealthCheckService.java
@@ -42,6 +42,7 @@ public class HealthCheckService implements IHealthCheckService {
     private final PredictiveMaintenanceService predictiveMaintenanceService;
     private final AlertNotificationService alertNotificationService;
     private final AtivoHealthHistoryRepository ativoHealthHistoryRepository;
+    private final MaintenanceDispatcherService maintenanceDispatcherService;
 
     public HealthCheckService(AtivoRepository ativoRepository,
                               AtivoDetalheHardwareRepository detalheHardwareRepository,
@@ -53,7 +54,8 @@ public class HealthCheckService implements IHealthCheckService {
                               HealthCheckHistoryRepository healthCheckHistoryRepository,
                               PredictiveMaintenanceService predictiveMaintenanceService,
                               AlertNotificationService alertNotificationService,
-                              AtivoHealthHistoryRepository ativoHealthHistoryRepository) {
+                              AtivoHealthHistoryRepository ativoHealthHistoryRepository,
+                              MaintenanceDispatcherService maintenanceDispatcherService) {
         this.ativoRepository = ativoRepository;
         this.detalheHardwareRepository = detalheHardwareRepository;
         this.currentUserProvider = currentUserProvider;
@@ -65,6 +67,7 @@ public class HealthCheckService implements IHealthCheckService {
         this.predictiveMaintenanceService = predictiveMaintenanceService;
         this.alertNotificationService = alertNotificationService;
         this.ativoHealthHistoryRepository = ativoHealthHistoryRepository;
+        this.maintenanceDispatcherService = maintenanceDispatcherService;
     }
 
     @Override
@@ -230,6 +233,9 @@ public class HealthCheckService implements IHealthCheckService {
                         ativo.getAtributos().put("prediction_calculated_at", java.time.LocalDateTime.now().toString());
 
                         ativo.setPrevisaoEsgotamentoDisco(worstPredictionResult.exhaustionDate());
+
+                        // Autonomous dispatch
+                        maintenanceDispatcherService.dispatchIfNecessary(ativo, worstPredictionResult.exhaustionDate());
                     }
                 }
             }

--- a/src/main/java/br/com/aegispatrimonio/service/MaintenanceDispatcherService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/MaintenanceDispatcherService.java
@@ -1,0 +1,56 @@
+package br.com.aegispatrimonio.service;
+
+import br.com.aegispatrimonio.model.Ativo;
+import br.com.aegispatrimonio.model.StatusManutencao;
+import br.com.aegispatrimonio.model.TipoManutencao;
+import br.com.aegispatrimonio.repository.ManutencaoRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.Set;
+
+/**
+ * Autonomous agent responsible for dispatching maintenance requests based on predictive analysis.
+ * Acts as the bridge between "Health Monitoring" and "Service Management".
+ */
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class MaintenanceDispatcherService {
+
+    private final ManutencaoRepository manutencaoRepository;
+    private final ManutencaoService manutencaoService;
+
+    @Transactional
+    public void dispatchIfNecessary(Ativo ativo, LocalDate predictionDate) {
+        if (predictionDate == null) {
+            return;
+        }
+
+        long daysUntilFailure = ChronoUnit.DAYS.between(LocalDate.now(), predictionDate);
+
+        // Threshold: 7 days or less
+        if (daysUntilFailure <= 7) {
+            // Check for existing open tickets to prevent spam
+            boolean hasOpenTicket = manutencaoRepository.existsByAtivoIdAndStatusIn(
+                    ativo.getId(),
+                    Set.of(StatusManutencao.SOLICITADA, StatusManutencao.APROVADA, StatusManutencao.EM_ANDAMENTO)
+            );
+
+            if (!hasOpenTicket) {
+                String description = String.format("Manutenção Preditiva Automática: Previsão de esgotamento de disco em %d dias (%s). Ação imediata recomendada.",
+                        daysUntilFailure, predictionDate);
+
+                log.info("SYSTEM: Dispatching autonomous maintenance for Ativo {} due to critical prediction.", ativo.getId());
+
+                manutencaoService.criarManutencaoSistemica(ativo, description, TipoManutencao.PREDITIVA);
+            } else {
+                log.debug("SYSTEM: Critical prediction for Ativo {}, but open maintenance ticket already exists.", ativo.getId());
+            }
+        }
+    }
+}

--- a/src/test/java/br/com/aegispatrimonio/service/MaintenanceDispatcherServiceTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/MaintenanceDispatcherServiceTest.java
@@ -1,0 +1,72 @@
+package br.com.aegispatrimonio.service;
+
+import br.com.aegispatrimonio.model.Ativo;
+import br.com.aegispatrimonio.model.StatusManutencao;
+import br.com.aegispatrimonio.model.TipoManutencao;
+import br.com.aegispatrimonio.repository.ManutencaoRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.util.Set;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MaintenanceDispatcherServiceTest {
+
+    @Mock
+    private ManutencaoRepository manutencaoRepository;
+
+    @Mock
+    private ManutencaoService manutencaoService;
+
+    private MaintenanceDispatcherService maintenanceDispatcherService;
+
+    @BeforeEach
+    void setUp() {
+        maintenanceDispatcherService = new MaintenanceDispatcherService(manutencaoRepository, manutencaoService);
+    }
+
+    @Test
+    void shouldDispatchWhenCriticalAndNoTicket() {
+        Ativo ativo = new Ativo();
+        ativo.setId(1L);
+        LocalDate criticalDate = LocalDate.now().plusDays(5);
+
+        when(manutencaoRepository.existsByAtivoIdAndStatusIn(eq(1L), anySet())).thenReturn(false);
+
+        maintenanceDispatcherService.dispatchIfNecessary(ativo, criticalDate);
+
+        verify(manutencaoService).criarManutencaoSistemica(eq(ativo), contains("Manutenção Preditiva Automática"), eq(TipoManutencao.PREDITIVA));
+    }
+
+    @Test
+    void shouldNotDispatchWhenNotCritical() {
+        Ativo ativo = new Ativo();
+        ativo.setId(1L);
+        LocalDate safeDate = LocalDate.now().plusDays(10);
+
+        maintenanceDispatcherService.dispatchIfNecessary(ativo, safeDate);
+
+        verify(manutencaoRepository, never()).existsByAtivoIdAndStatusIn(anyLong(), anySet());
+        verify(manutencaoService, never()).criarManutencaoSistemica(any(), anyString(), any());
+    }
+
+    @Test
+    void shouldNotDispatchWhenTicketExists() {
+        Ativo ativo = new Ativo();
+        ativo.setId(1L);
+        LocalDate criticalDate = LocalDate.now().plusDays(3);
+
+        when(manutencaoRepository.existsByAtivoIdAndStatusIn(eq(1L), anySet())).thenReturn(true);
+
+        maintenanceDispatcherService.dispatchIfNecessary(ativo, criticalDate);
+
+        verify(manutencaoService, never()).criarManutencaoSistemica(any(), anyString(), any());
+    }
+}


### PR DESCRIPTION
This PR implements the "Autonomous Maintenance Dispatcher" innovation task. 

It closes the loop between Predictive Maintenance (HealthCheck) and Service Management (Manutencao). When the system predicts a critical failure (e.g., Disk exhaustion within 7 days), it automatically creates a maintenance ticket on behalf of the asset owner, provided no open ticket already exists.

Key components:
1. `MaintenanceDispatcherService`: The logic brain.
2. `ManutencaoService.criarManutencaoSistemica`: Enables system-driven ticket creation.
3. Integration in `HealthCheckService`: Triggers the dispatch after prediction calculation.

---
*PR created automatically by Jules for task [11656496107955711098](https://jules.google.com/task/11656496107955711098) started by @diogo-rp-menezes*