### PR TITLE
fix(frontend): enable drill-down filtering from dashboard predictive cards

### DIFF
--- a/frontend/e2e/dashboard-predictive.spec.js
+++ b/frontend/e2e/dashboard-predictive.spec.js
@@ -79,4 +79,13 @@ test.describe('Dashboard Predictive Visualization (SOTA)', () => {
     await expect(unknownCard.locator('h3')).toHaveText('5 ativos');
   });
 
+  test('Deve navegar para lista de ativos filtrada ao clicar no card', async ({ page }) => {
+    // Click on the "Indeterminado" card
+    const unknownCard = page.locator('.card', { hasText: 'Indeterminado' });
+    await unknownCard.click();
+
+    // Verify URL parameters
+    await expect(page).toHaveURL(/.*\/ativos\?health=INDETERMINADO/);
+  });
+
 });

--- a/frontend/src/views/DashboardInfo.vue
+++ b/frontend/src/views/DashboardInfo.vue
@@ -308,7 +308,7 @@ onMounted(async () => {
       <div class="col-lg-8">
         <div class="row g-3 h-100">
           <div v-for="stat in predictiveStats" :key="stat.title" class="col-md-6 col-xl-4">
-            <div class="card h-100 border-0 shadow-sm">
+            <div class="card h-100 border-0 shadow-sm predictive-card" @click="goToAssets(stat.filter)">
               <div class="card-body d-flex align-items-center">
                 <div
                   :class="`bg-${stat.color} text-white rounded-circle d-flex align-items-center justify-content-center me-3 shadow-sm`"


### PR DESCRIPTION
This PR fixes a UX issue where the Predictive Maintenance cards on the Dashboard were not interactive.
It enables drill-down functionality, allowing users to click on a status card (e.g., "Indeterminado") and navigate to the Asset List filtered by that status.

Changes:
- `frontend/src/views/DashboardInfo.vue`: Added `@click` listener and CSS class.
- `frontend/e2e/dashboard-predictive.spec.js`: Added E2E test case for navigation.

Verified with Playwright script and manual inspection of existing code (ensuring helper functions and CSS were present).

---
*PR created automatically by Jules for task [8829000180376626619](https://jules.google.com/task/8829000180376626619) started by @diogo-rp-menezes*