### PR TITLE
Implement RBAC Groups

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/controller/GroupController.java
+++ b/src/main/java/br/com/aegispatrimonio/controller/GroupController.java
@@ -1,0 +1,61 @@
+package br.com.aegispatrimonio.controller;
+
+import br.com.aegispatrimonio.dto.GroupCreateDTO;
+import br.com.aegispatrimonio.dto.GroupDTO;
+import br.com.aegispatrimonio.dto.GroupUpdateDTO;
+import br.com.aegispatrimonio.service.RbacManagementService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/groups")
+@Tag(name = "Groups", description = "Gerenciamento de Grupos de Acesso")
+@SecurityRequirement(name = "bearerAuth")
+@PreAuthorize("hasRole('ADMIN')")
+public class GroupController {
+
+    private final RbacManagementService rbacService;
+
+    public GroupController(RbacManagementService rbacService) {
+        this.rbacService = rbacService;
+    }
+
+    @GetMapping
+    @Operation(summary = "Lista todos os grupos")
+    public List<GroupDTO> listarTodos() {
+        return rbacService.listarGrupos();
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "Busca grupo por ID")
+    public GroupDTO buscarPorId(@PathVariable Long id) {
+        return rbacService.buscarGrupoPorId(id);
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    @Operation(summary = "Cria um novo grupo")
+    public GroupDTO criar(@Valid @RequestBody GroupCreateDTO dto) {
+        return rbacService.criarGrupo(dto);
+    }
+
+    @PutMapping("/{id}")
+    @Operation(summary = "Atualiza um grupo existente")
+    public GroupDTO atualizar(@PathVariable Long id, @Valid @RequestBody GroupUpdateDTO dto) {
+        return rbacService.atualizarGrupo(id, dto);
+    }
+
+    @DeleteMapping("/{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @Operation(summary = "Deleta um grupo")
+    public void deletar(@PathVariable Long id) {
+        rbacService.deletarGrupo(id);
+    }
+}

--- a/src/main/java/br/com/aegispatrimonio/dto/GroupCreateDTO.java
+++ b/src/main/java/br/com/aegispatrimonio/dto/GroupCreateDTO.java
@@ -1,0 +1,11 @@
+package br.com.aegispatrimonio.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.Set;
+
+public record GroupCreateDTO(
+    @NotBlank(message = "O nome é obrigatório")
+    String name,
+    String description,
+    Set<Long> permissionIds
+) {}

--- a/src/main/java/br/com/aegispatrimonio/dto/GroupDTO.java
+++ b/src/main/java/br/com/aegispatrimonio/dto/GroupDTO.java
@@ -1,0 +1,10 @@
+package br.com.aegispatrimonio.dto;
+
+import java.util.Set;
+
+public record GroupDTO(
+    Long id,
+    String name,
+    String description,
+    Set<PermissionDTO> permissions
+) {}

--- a/src/main/java/br/com/aegispatrimonio/dto/GroupUpdateDTO.java
+++ b/src/main/java/br/com/aegispatrimonio/dto/GroupUpdateDTO.java
@@ -1,0 +1,11 @@
+package br.com.aegispatrimonio.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import java.util.Set;
+
+public record GroupUpdateDTO(
+    @NotBlank(message = "O nome é obrigatório")
+    String name,
+    String description,
+    Set<Long> permissionIds
+) {}

--- a/src/main/java/br/com/aegispatrimonio/mapper/RbacMapper.java
+++ b/src/main/java/br/com/aegispatrimonio/mapper/RbacMapper.java
@@ -1,7 +1,9 @@
 package br.com.aegispatrimonio.mapper;
 
+import br.com.aegispatrimonio.dto.GroupDTO;
 import br.com.aegispatrimonio.dto.PermissionDTO;
 import br.com.aegispatrimonio.dto.RoleDTO;
+import br.com.aegispatrimonio.model.Group;
 import br.com.aegispatrimonio.model.Permission;
 import br.com.aegispatrimonio.model.Role;
 import org.springframework.stereotype.Component;
@@ -40,6 +42,25 @@ public class RbacMapper {
             role.getId(),
             role.getName(),
             role.getDescription(),
+            permissionDTOs
+        );
+    }
+
+    public GroupDTO toGroupDTO(Group group) {
+        if (group == null) {
+            return null;
+        }
+        Set<PermissionDTO> permissionDTOs = null;
+        if (group.getPermissions() != null) {
+            permissionDTOs = group.getPermissions().stream()
+                .map(this::toPermissionDTO)
+                .collect(Collectors.toSet());
+        }
+
+        return new GroupDTO(
+            group.getId(),
+            group.getName(),
+            group.getDescription(),
             permissionDTOs
         );
     }

--- a/src/main/java/br/com/aegispatrimonio/model/Group.java
+++ b/src/main/java/br/com/aegispatrimonio/model/Group.java
@@ -1,0 +1,37 @@
+package br.com.aegispatrimonio.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Table(name = "rbac_group")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Group {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 64)
+    private String name;
+
+    @Column(length = 255)
+    private String description;
+
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "rbac_group_permission",
+        joinColumns = @JoinColumn(name = "group_id"),
+        inverseJoinColumns = @JoinColumn(name = "permission_id")
+    )
+    private Set<Permission> permissions = new HashSet<>();
+}

--- a/src/main/java/br/com/aegispatrimonio/model/Usuario.java
+++ b/src/main/java/br/com/aegispatrimonio/model/Usuario.java
@@ -45,6 +45,14 @@ public class Usuario {
     )
     private Set<Role> roles = new HashSet<>();
 
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+        name = "rbac_user_group",
+        joinColumns = @JoinColumn(name = "user_id"),
+        inverseJoinColumns = @JoinColumn(name = "group_id")
+    )
+    private Set<Group> groups = new HashSet<>();
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Status status;

--- a/src/main/java/br/com/aegispatrimonio/repository/GroupRepository.java
+++ b/src/main/java/br/com/aegispatrimonio/repository/GroupRepository.java
@@ -1,0 +1,18 @@
+package br.com.aegispatrimonio.repository;
+
+import br.com.aegispatrimonio.model.Group;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface GroupRepository extends JpaRepository<Group, Long> {
+
+    Optional<Group> findByName(String name);
+
+    @EntityGraph(attributePaths = {"permissions"})
+    List<Group> findAll();
+}

--- a/src/main/java/br/com/aegispatrimonio/repository/UsuarioRepository.java
+++ b/src/main/java/br/com/aegispatrimonio/repository/UsuarioRepository.java
@@ -24,7 +24,7 @@ public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
      * @param email O email a ser buscado.
      * @return Um Optional contendo o usuário, se encontrado.
      */
-    @org.springframework.data.jpa.repository.EntityGraph(attributePaths = {"funcionario", "funcionario.filiais", "roles", "roles.permissions"})
+    @org.springframework.data.jpa.repository.EntityGraph(attributePaths = {"funcionario", "funcionario.filiais", "roles", "roles.permissions", "groups", "groups.permissions"})
     @org.springframework.data.jpa.repository.Query("SELECT u FROM Usuario u WHERE u.email = :email")
     Optional<Usuario> findWithDetailsByEmail(String email);
 }

--- a/src/main/java/br/com/aegispatrimonio/service/impl/PermissionServiceImpl.java
+++ b/src/main/java/br/com/aegispatrimonio/service/impl/PermissionServiceImpl.java
@@ -1,6 +1,7 @@
 package br.com.aegispatrimonio.service.impl;
 
 import br.com.aegispatrimonio.model.Filial;
+import br.com.aegispatrimonio.model.Group;
 import br.com.aegispatrimonio.model.Permission;
 import br.com.aegispatrimonio.model.Role;
 import br.com.aegispatrimonio.repository.AtivoRepository;
@@ -207,6 +208,13 @@ public class PermissionServiceImpl implements IPermissionService {
                         for (Role role : u.getRoles()) {
                             if (role.getPermissions() != null) {
                                 perms.addAll(role.getPermissions());
+                            }
+                        }
+                    }
+                    if (u.getGroups() != null) {
+                        for (Group group : u.getGroups()) {
+                            if (group.getPermissions() != null) {
+                                perms.addAll(group.getPermissions());
                             }
                         }
                     }

--- a/src/main/resources/db/migration/V13__create_rbac_group_tables.sql
+++ b/src/main/resources/db/migration/V13__create_rbac_group_tables.sql
@@ -1,0 +1,30 @@
+-- V13__create_rbac_group_tables.sql
+
+CREATE TABLE rbac_group (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(64) NOT NULL UNIQUE,
+    description VARCHAR(255)
+);
+
+CREATE TABLE rbac_group_permission (
+    group_id BIGINT NOT NULL,
+    permission_id BIGINT NOT NULL,
+    PRIMARY KEY (group_id, permission_id),
+    CONSTRAINT fk_group_perm_group FOREIGN KEY (group_id) REFERENCES rbac_group(id) ON DELETE CASCADE,
+    CONSTRAINT fk_group_perm_perm FOREIGN KEY (permission_id) REFERENCES rbac_permission(id) ON DELETE CASCADE
+);
+
+CREATE TABLE rbac_user_group (
+    user_id BIGINT NOT NULL,
+    group_id BIGINT NOT NULL,
+    PRIMARY KEY (user_id, group_id),
+    CONSTRAINT fk_user_group_user FOREIGN KEY (user_id) REFERENCES usuarios(id) ON DELETE CASCADE,
+    CONSTRAINT fk_user_group_group FOREIGN KEY (group_id) REFERENCES rbac_group(id) ON DELETE CASCADE
+);
+
+-- Indexes
+CREATE INDEX idx_group_perm_group ON rbac_group_permission(group_id);
+CREATE INDEX idx_user_group_user ON rbac_user_group(user_id);
+
+-- Seed Data: Group
+INSERT INTO rbac_group (name, description) VALUES ('GROUP_DEFAULT', 'Grupo padrão de exemplo');

--- a/src/test/java/br/com/aegispatrimonio/controller/GroupControllerIT.java
+++ b/src/test/java/br/com/aegispatrimonio/controller/GroupControllerIT.java
@@ -1,0 +1,57 @@
+package br.com.aegispatrimonio.controller;
+
+import br.com.aegispatrimonio.BaseIT;
+import br.com.aegispatrimonio.dto.GroupCreateDTO;
+import br.com.aegispatrimonio.model.Group;
+import br.com.aegispatrimonio.repository.GroupRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.HashSet;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@AutoConfigureMockMvc
+class GroupControllerIT extends BaseIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void shouldCreateGroup() throws Exception {
+        GroupCreateDTO dto = new GroupCreateDTO("New Group", "Description", new HashSet<>());
+
+        mockMvc.perform(post("/api/v1/groups")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(dto)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name", is("New Group")));
+    }
+
+    @Test
+    @WithMockUser(roles = "ADMIN")
+    void shouldListGroups() throws Exception {
+        groupRepository.save(new Group(null, "Group 1", "Desc 1", new HashSet<>()));
+        groupRepository.save(new Group(null, "Group 2", "Desc 2", new HashSet<>()));
+
+        mockMvc.perform(get("/api/v1/groups"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)));
+    }
+}

--- a/src/test/java/br/com/aegispatrimonio/security/GroupPermissionIT.java
+++ b/src/test/java/br/com/aegispatrimonio/security/GroupPermissionIT.java
@@ -1,0 +1,64 @@
+package br.com.aegispatrimonio.security;
+
+import br.com.aegispatrimonio.BaseIT;
+import br.com.aegispatrimonio.model.*;
+import br.com.aegispatrimonio.repository.*;
+import br.com.aegispatrimonio.service.IPermissionService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class GroupPermissionIT extends BaseIT {
+
+    @Autowired
+    private UsuarioRepository usuarioRepository;
+
+    @Autowired
+    private GroupRepository groupRepository;
+
+    @Autowired
+    private PermissionRepository permissionRepository;
+
+    @Autowired
+    private IPermissionService permissionService;
+
+    @Test
+    @Transactional
+    void userShouldInheritPermissionsFromGroup() {
+        // 1. Create Permission
+        Permission p = new Permission(null, "TEST_RESOURCE", "READ", "Test Desc", null);
+        p = permissionRepository.save(p);
+
+        // 2. Create Group with Permission
+        Group g = new Group(null, "TEST_GROUP", "Desc", new HashSet<>());
+        g.getPermissions().add(p);
+        g = groupRepository.save(g);
+
+        // 3. Create User with Group
+        Usuario u = new Usuario();
+        u.setEmail("groupuser@example.com");
+        u.setPassword("pass");
+        u.setRole("ROLE_USER");
+        u.setStatus(Status.ATIVO);
+        u.setGroups(new HashSet<>());
+        u.getGroups().add(g);
+        u = usuarioRepository.save(u);
+
+        // 4. Authenticate
+        CustomUserDetails userDetails = new CustomUserDetails(u);
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        // 5. Verify
+        boolean hasPerm = permissionService.hasPermission(auth, null, "TEST_RESOURCE", "READ", null);
+        assertTrue(hasPerm, "User should have permission inherited from Group");
+    }
+}

--- a/src/test/resources/cleanup.sql
+++ b/src/test/resources/cleanup.sql
@@ -17,6 +17,9 @@ DELETE FROM tipos_ativo;
 DELETE FROM filiais;
 
 -- RBAC Cleanup
+DELETE FROM rbac_user_group;
+DELETE FROM rbac_group_permission;
+DELETE FROM rbac_group;
 DELETE FROM rbac_user_role;
 DELETE FROM rbac_role_permission;
 DELETE FROM rbac_permission;


### PR DESCRIPTION
Implemented Group-based Access Control to complete the RBAC administration module (Sprint 2). Users can now be assigned to groups, and they inherit permissions defined in those groups. This complements the existing Role-based system.

**Changes:**
- Database: New tables `rbac_group`, `rbac_group_permission`, `rbac_user_group`.
- Backend:
    - New Entity `Group`.
    - Updates to `Usuario`, `PermissionServiceImpl`.
    - New `GroupController` with CRUD.
    - Tests for API and permission logic.

---
*PR created automatically by Jules for task [10867954158281753589](https://jules.google.com/task/10867954158281753589) started by @diogo-rp-menezes*