### PR TITLE
Refactor HealthCheck Auth Policy to use Granular RBAC

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/service/IPermissionService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/IPermissionService.java
@@ -31,4 +31,9 @@ public interface IPermissionService {
      * Verifica permissão em um Funcionário específico, resolvendo o contexto (Filiais) automaticamente.
      */
     boolean hasFuncionarioPermission(Authentication authentication, Long funcionarioId, String action);
+
+    /**
+     * Verifica se o usuário possui um papel específico (role).
+     */
+    boolean hasRole(String username, String roleName);
 }

--- a/src/main/java/br/com/aegispatrimonio/service/UserContextService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/UserContextService.java
@@ -19,12 +19,14 @@ public class UserContextService {
 
     private final CurrentUserProvider currentUserProvider;
     private final FuncionarioRepository funcionarioRepository;
+    private final IPermissionService permissionService;
 
     private Funcionario cachedFuncionario;
 
-    public UserContextService(CurrentUserProvider currentUserProvider, FuncionarioRepository funcionarioRepository) {
+    public UserContextService(CurrentUserProvider currentUserProvider, FuncionarioRepository funcionarioRepository, IPermissionService permissionService) {
         this.currentUserProvider = currentUserProvider;
         this.funcionarioRepository = funcionarioRepository;
+        this.permissionService = permissionService;
     }
 
     public Usuario getCurrentUser() {
@@ -33,7 +35,7 @@ public class UserContextService {
 
     public boolean isAdmin() {
         Usuario usuario = getCurrentUser();
-        return "ROLE_ADMIN".equals(usuario.getRole());
+        return permissionService.hasRole(usuario.getEmail(), "ROLE_ADMIN");
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/br/com/aegispatrimonio/service/policy/DefaultHealthCheckAuthorizationPolicy.java
+++ b/src/main/java/br/com/aegispatrimonio/service/policy/DefaultHealthCheckAuthorizationPolicy.java
@@ -1,54 +1,32 @@
 package br.com.aegispatrimonio.service.policy;
 
 import br.com.aegispatrimonio.model.Ativo;
-import br.com.aegispatrimonio.model.Funcionario;
 import br.com.aegispatrimonio.model.Usuario;
-import br.com.aegispatrimonio.repository.FuncionarioRepository;
+import br.com.aegispatrimonio.service.IPermissionService;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 @Component
 public class DefaultHealthCheckAuthorizationPolicy implements HealthCheckAuthorizationPolicy {
 
-    private final FuncionarioRepository funcionarioRepository;
+    private final IPermissionService permissionService;
 
-    public DefaultHealthCheckAuthorizationPolicy(FuncionarioRepository funcionarioRepository) {
-        this.funcionarioRepository = funcionarioRepository;
+    public DefaultHealthCheckAuthorizationPolicy(IPermissionService permissionService) {
+        this.permissionService = permissionService;
     }
 
     @Override
     public void assertCanUpdate(Usuario usuario, Ativo ativo) {
-        if (isAdmin(usuario)) {
-            return;
+        var auth = SecurityContextHolder.getContext().getAuthentication();
+
+        if (auth == null || !auth.isAuthenticated()) {
+             throw new AccessDeniedException("Não há contexto de segurança autenticado.");
         }
 
-        Funcionario funcionarioLogado = usuario.getFuncionario();
-        if (funcionarioLogado == null) {
-            throw new AccessDeniedException("Usuário não está associado a um funcionário.");
+        // Delegate to Granular RBAC service which handles Admin bypass, Role checks and Context (Filial) verification
+        if (!permissionService.hasAtivoPermission(auth, ativo.getId(), "UPDATE")) {
+             throw new AccessDeniedException("Você não tem permissão para acessar/modificar este ativo.");
         }
-
-        // Recarregar o funcionário para garantir que as filiais estão atualizadas (evitar LazyInitializationException)
-        Optional<Funcionario> optionalFuncionario = funcionarioRepository.findById(funcionarioLogado.getId());
-        if (optionalFuncionario.isEmpty()) {
-            throw new AccessDeniedException("Funcionário associado ao usuário não foi encontrado no sistema.");
-        }
-        funcionarioLogado = optionalFuncionario.get();
-
-        if (funcionarioLogado.getFiliais() == null || funcionarioLogado.getFiliais().isEmpty()) {
-            throw new AccessDeniedException("Usuário não está associado a nenhuma filial.");
-        }
-
-        boolean temAcesso = funcionarioLogado.getFiliais().stream()
-                .anyMatch(f -> f.getId().equals(ativo.getFilial().getId()));
-
-        if (!temAcesso) {
-            throw new AccessDeniedException("Você não tem permissão para acessar/modificar este ativo.");
-        }
-    }
-
-    private boolean isAdmin(Usuario usuario) {
-        return "ROLE_ADMIN".equals(usuario.getRole());
     }
 }

--- a/src/test/java/br/com/aegispatrimonio/service/policy/DefaultHealthCheckAuthorizationPolicyTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/policy/DefaultHealthCheckAuthorizationPolicyTest.java
@@ -1,10 +1,9 @@
 package br.com.aegispatrimonio.service.policy;
 
 import br.com.aegispatrimonio.model.Ativo;
-import br.com.aegispatrimonio.model.Filial;
-import br.com.aegispatrimonio.model.Funcionario;
 import br.com.aegispatrimonio.model.Usuario;
-import br.com.aegispatrimonio.repository.FuncionarioRepository;
+import br.com.aegispatrimonio.service.IPermissionService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,135 +12,86 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.access.AccessDeniedException;
-
-import java.util.Collections;
-import java.util.Optional;
-import java.util.Set;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class DefaultHealthCheckAuthorizationPolicyTest {
 
     @Mock
-    private FuncionarioRepository funcionarioRepository;
+    private IPermissionService permissionService;
+
+    @Mock
+    private SecurityContext securityContext;
+
+    @Mock
+    private Authentication authentication;
 
     @InjectMocks
     private DefaultHealthCheckAuthorizationPolicy policy;
 
-    private Usuario adminUser;
-    private Usuario regularUserFilialA;
-    private Usuario regularUserFilialB;
-    private Usuario userWithoutFuncionario;
-    private Usuario userWithNonExistentFuncionario;
-    private Usuario userWithFuncionarioNoFiliais;
-    private Ativo ativoFilialA;
-    private Ativo ativoFilialB;
-    private Filial filialA;
-    private Filial filialB;
-    private Funcionario funcionarioFilialA;
-    private Funcionario funcionarioFilialB;
+    private Usuario usuario;
+    private Ativo ativo;
 
     @BeforeEach
     void setUp() {
-        filialA = new Filial();
-        filialA.setId(1L);
-        filialA.setNome("Filial A");
+        SecurityContextHolder.setContext(securityContext);
 
-        filialB = new Filial();
-        filialB.setId(2L);
-        filialB.setNome("Filial B");
+        usuario = new Usuario();
+        usuario.setId(1L);
 
-        ativoFilialA = new Ativo();
-        ativoFilialA.setId(100L);
-        ativoFilialA.setFilial(filialA);
+        ativo = new Ativo();
+        ativo.setId(100L);
+    }
 
-        ativoFilialB = new Ativo();
-        ativoFilialB.setId(101L);
-        ativoFilialB.setFilial(filialB);
-
-        // Admin User
-        adminUser = new Usuario();
-        adminUser.setRole("ROLE_ADMIN");
-        adminUser.setFuncionario(new Funcionario()); // Pode ter um funcionário, mas a role ADMIN ignora
-
-        // Regular User for Filial A
-        funcionarioFilialA = new Funcionario();
-        funcionarioFilialA.setId(1L);
-        funcionarioFilialA.setFiliais(Set.of(filialA));
-        regularUserFilialA = new Usuario();
-        regularUserFilialA.setRole("ROLE_USER");
-        regularUserFilialA.setFuncionario(funcionarioFilialA);
-
-        // Regular User for Filial B
-        funcionarioFilialB = new Funcionario();
-        funcionarioFilialB.setId(2L);
-        funcionarioFilialB.setFiliais(Set.of(filialB));
-        regularUserFilialB = new Usuario();
-        regularUserFilialB.setRole("ROLE_USER");
-        regularUserFilialB.setFuncionario(funcionarioFilialB);
-
-        // User without Funcionario
-        userWithoutFuncionario = new Usuario();
-        userWithoutFuncionario.setRole("ROLE_USER");
-        userWithoutFuncionario.setFuncionario(null);
-
-        // User with non-existent Funcionario
-        Funcionario nonExistentFunc = new Funcionario();
-        nonExistentFunc.setId(99L);
-        userWithNonExistentFuncionario = new Usuario();
-        userWithNonExistentFuncionario.setRole("ROLE_USER");
-        userWithNonExistentFuncionario.setFuncionario(nonExistentFunc);
-
-        // User with Funcionario but no associated Filiais
-        Funcionario funcNoFiliais = new Funcionario();
-        funcNoFiliais.setId(3L);
-        funcNoFiliais.setFiliais(Collections.emptySet());
-        userWithFuncionarioNoFiliais = new Usuario();
-        userWithFuncionarioNoFiliais.setRole("ROLE_USER");
-        userWithFuncionarioNoFiliais.setFuncionario(funcNoFiliais);
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     @Test
-    @DisplayName("ADMIN user should be able to update any asset")
-    void assertCanUpdate_adminUser_shouldNotThrowException() {
-        assertDoesNotThrow(() -> policy.assertCanUpdate(adminUser, ativoFilialA));
-        assertDoesNotThrow(() -> policy.assertCanUpdate(adminUser, ativoFilialB));
+    @DisplayName("Should throw AccessDeniedException if no authentication in context")
+    void assertCanUpdate_noAuth_shouldThrowException() {
+        when(securityContext.getAuthentication()).thenReturn(null);
+
+        assertThrows(AccessDeniedException.class, () -> policy.assertCanUpdate(usuario, ativo));
     }
 
     @Test
-    @DisplayName("Regular user with access to asset's filial should be able to update")
-    void assertCanUpdate_regularUserWithAccess_shouldNotThrowException() {
-        when(funcionarioRepository.findById(funcionarioFilialA.getId())).thenReturn(Optional.of(funcionarioFilialA));
-        assertDoesNotThrow(() -> policy.assertCanUpdate(regularUserFilialA, ativoFilialA));
+    @DisplayName("Should throw AccessDeniedException if not authenticated")
+    void assertCanUpdate_notAuthenticated_shouldThrowException() {
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.isAuthenticated()).thenReturn(false);
+
+        assertThrows(AccessDeniedException.class, () -> policy.assertCanUpdate(usuario, ativo));
     }
 
     @Test
-    @DisplayName("Regular user without access to asset's filial should throw AccessDeniedException")
-    void assertCanUpdate_regularUserWithoutAccess_shouldThrowAccessDeniedException() {
-        when(funcionarioRepository.findById(funcionarioFilialA.getId())).thenReturn(Optional.of(funcionarioFilialA));
-        assertThrows(AccessDeniedException.class, () -> policy.assertCanUpdate(regularUserFilialA, ativoFilialB));
+    @DisplayName("Should allow update if permissionService returns true")
+    void assertCanUpdate_permissionGranted_shouldAllow() {
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(permissionService.hasAtivoPermission(authentication, ativo.getId(), "UPDATE")).thenReturn(true);
+
+        assertDoesNotThrow(() -> policy.assertCanUpdate(usuario, ativo));
+
+        verify(permissionService).hasAtivoPermission(authentication, ativo.getId(), "UPDATE");
     }
 
     @Test
-    @DisplayName("User without an associated Funcionario should throw AccessDeniedException")
-    void assertCanUpdate_userWithoutFuncionario_shouldThrowAccessDeniedException() {
-        assertThrows(AccessDeniedException.class, () -> policy.assertCanUpdate(userWithoutFuncionario, ativoFilialA));
-    }
+    @DisplayName("Should throw AccessDeniedException if permissionService returns false")
+    void assertCanUpdate_permissionDenied_shouldThrowException() {
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.isAuthenticated()).thenReturn(true);
+        when(permissionService.hasAtivoPermission(authentication, ativo.getId(), "UPDATE")).thenReturn(false);
 
-    @Test
-    @DisplayName("User with a non-existent Funcionario should throw AccessDeniedException")
-    void assertCanUpdate_userWithNonExistentFuncionario_shouldThrowAccessDeniedException() {
-        when(funcionarioRepository.findById(userWithNonExistentFuncionario.getFuncionario().getId())).thenReturn(Optional.empty());
-        assertThrows(AccessDeniedException.class, () -> policy.assertCanUpdate(userWithNonExistentFuncionario, ativoFilialA));
-    }
-
-    @Test
-    @DisplayName("User with Funcionario but no associated filiais should throw AccessDeniedException")
-    void assertCanUpdate_userWithFuncionarioNoFiliais_shouldThrowAccessDeniedException() {
-        when(funcionarioRepository.findById(userWithFuncionarioNoFiliais.getFuncionario().getId())).thenReturn(Optional.of(userWithFuncionarioNoFiliais.getFuncionario()));
-        assertThrows(AccessDeniedException.class, () -> policy.assertCanUpdate(userWithFuncionarioNoFiliais, ativoFilialA));
+        assertThrows(AccessDeniedException.class, () -> policy.assertCanUpdate(usuario, ativo));
     }
 }


### PR DESCRIPTION
Replaced "mock-like" authorization logic in `DefaultHealthCheckAuthorizationPolicy` and `UserContextService` (which checked `usuario.getRole()` string directly) with the real Granular RBAC implementation provided by `PermissionService`. This ensures that permissions and context access (Filiais) are correctly enforced via the centralized permission system.

Key changes:
- `IPermissionService`: Added `hasRole` method.
- `UserContextService`: Injected `IPermissionService` and removed `ROLE_ADMIN` string check.
- `DefaultHealthCheckAuthorizationPolicy`: Injected `IPermissionService`, removed `FuncionarioRepository`, and delegates `assertCanUpdate` to `permissionService.hasAtivoPermission`.
- Tests: Updated `DefaultHealthCheckAuthorizationPolicyTest` to verify interactions with `IPermissionService` and `SecurityContext`.

---
*PR created automatically by Jules for task [4888979952644212570](https://jules.google.com/task/4888979952644212570) started by @diogo-rp-menezes*