### PR TITLE
Refactor HealthCheckService: Extract Prediction Logic

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/service/manager/DefaultHealthCheckPredictionManager.java
+++ b/src/main/java/br/com/aegispatrimonio/service/manager/DefaultHealthCheckPredictionManager.java
@@ -1,0 +1,93 @@
+package br.com.aegispatrimonio.service.manager;
+
+import br.com.aegispatrimonio.dto.PredictionResult;
+import br.com.aegispatrimonio.model.Ativo;
+import br.com.aegispatrimonio.model.AtivoHealthHistory;
+import br.com.aegispatrimonio.repository.AtivoHealthHistoryRepository;
+import br.com.aegispatrimonio.service.MaintenanceDispatcherService;
+import br.com.aegispatrimonio.service.PredictiveMaintenanceService;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Default implementation of HealthCheckPredictionManager.
+ * Orchestrates the predictive maintenance workflow: throttling -> fetching -> prediction -> update -> dispatch.
+ */
+@Component
+public class DefaultHealthCheckPredictionManager implements HealthCheckPredictionManager {
+
+    private final AtivoHealthHistoryRepository ativoHealthHistoryRepository;
+    private final PredictiveMaintenanceService predictiveMaintenanceService;
+    private final MaintenanceDispatcherService maintenanceDispatcherService;
+
+    public DefaultHealthCheckPredictionManager(AtivoHealthHistoryRepository ativoHealthHistoryRepository,
+                                               PredictiveMaintenanceService predictiveMaintenanceService,
+                                               MaintenanceDispatcherService maintenanceDispatcherService) {
+        this.ativoHealthHistoryRepository = ativoHealthHistoryRepository;
+        this.predictiveMaintenanceService = predictiveMaintenanceService;
+        this.maintenanceDispatcherService = maintenanceDispatcherService;
+    }
+
+    @Override
+    public void processPrediction(Ativo ativo, List<String> componentsToFetch) {
+        if (ativo == null || componentsToFetch == null || componentsToFetch.isEmpty()) {
+            return;
+        }
+
+        // Throttling: Check if prediction was calculated recently (< 24h)
+        boolean shouldRecalculate = true;
+        if (ativo.getAtributos() != null && ativo.getAtributos().containsKey("prediction_calculated_at")) {
+            try {
+                java.time.LocalDateTime lastCalc = java.time.LocalDateTime.parse(ativo.getAtributos().get("prediction_calculated_at").toString());
+                if (lastCalc.plusHours(24).isAfter(java.time.LocalDateTime.now())) {
+                    shouldRecalculate = false;
+                }
+            } catch (Exception e) {
+                // Ignore parse errors and recalculate
+            }
+        }
+
+        if (shouldRecalculate) {
+            // Fetch history for all components at once (Sliding Window: 90 days)
+            java.time.LocalDateTime cutoffDate = java.time.LocalDateTime.now().minusDays(90);
+            List<AtivoHealthHistory> allHistory = ativoHealthHistoryRepository
+                    .findByAtivoIdAndComponenteInAndMetricaAndDataRegistroAfterOrderByDataRegistroAsc(
+                            ativo.getId(), componentsToFetch, "FREE_SPACE_GB", cutoffDate);
+
+            // Group by component
+            java.util.Map<String, List<AtivoHealthHistory>> historyByComponent = allHistory.stream()
+                    .collect(Collectors.groupingBy(AtivoHealthHistory::getComponente));
+
+            PredictionResult worstPredictionResult = null;
+
+            for (List<AtivoHealthHistory> componentHistory : historyByComponent.values()) {
+                PredictionResult prediction = predictiveMaintenanceService.predictExhaustionDate(componentHistory);
+                if (prediction != null && prediction.exhaustionDate() != null) {
+                    if (worstPredictionResult == null ||
+                            prediction.exhaustionDate().isBefore(worstPredictionResult.exhaustionDate())) {
+                        worstPredictionResult = prediction;
+                    }
+                }
+            }
+
+            // Store worst prediction in attributes
+            if (worstPredictionResult != null) {
+                if (ativo.getAtributos() == null) {
+                    ativo.setAtributos(new java.util.HashMap<>());
+                }
+                ativo.getAtributos().put("previsaoEsgotamentoDisco", worstPredictionResult.exhaustionDate().toString());
+                ativo.getAtributos().put("prediction_slope", worstPredictionResult.slope());
+                ativo.getAtributos().put("prediction_intercept", worstPredictionResult.intercept());
+                ativo.getAtributos().put("prediction_base_epoch_day", worstPredictionResult.baseEpochDay());
+                ativo.getAtributos().put("prediction_calculated_at", java.time.LocalDateTime.now().toString());
+
+                ativo.setPrevisaoEsgotamentoDisco(worstPredictionResult.exhaustionDate());
+
+                // Autonomous dispatch
+                maintenanceDispatcherService.dispatchIfNecessary(ativo, worstPredictionResult.exhaustionDate());
+            }
+        }
+    }
+}

--- a/src/main/java/br/com/aegispatrimonio/service/manager/HealthCheckPredictionManager.java
+++ b/src/main/java/br/com/aegispatrimonio/service/manager/HealthCheckPredictionManager.java
@@ -1,0 +1,21 @@
+package br.com.aegispatrimonio.service.manager;
+
+import br.com.aegispatrimonio.model.Ativo;
+
+import java.util.List;
+
+/**
+ * Interface for managing predictive maintenance logic during Health Check processing.
+ */
+public interface HealthCheckPredictionManager {
+
+    /**
+     * Processes predictive analysis for the given asset based on historical data of the specified components.
+     * Checks if prediction is needed (throttling), fetches history, calculates prediction,
+     * updates asset attributes, and dispatches maintenance if necessary.
+     *
+     * @param ativo The asset to analyze and update.
+     * @param componentsToFetch The list of component identifiers (e.g. "DISK:SN123") to fetch history for.
+     */
+    void processPrediction(Ativo ativo, List<String> componentsToFetch);
+}

--- a/src/test/java/br/com/aegispatrimonio/service/manager/DefaultHealthCheckPredictionManagerTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/manager/DefaultHealthCheckPredictionManagerTest.java
@@ -1,0 +1,112 @@
+package br.com.aegispatrimonio.service.manager;
+
+import br.com.aegispatrimonio.dto.PredictionResult;
+import br.com.aegispatrimonio.model.Ativo;
+import br.com.aegispatrimonio.model.AtivoHealthHistory;
+import br.com.aegispatrimonio.repository.AtivoHealthHistoryRepository;
+import br.com.aegispatrimonio.service.MaintenanceDispatcherService;
+import br.com.aegispatrimonio.service.PredictiveMaintenanceService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class DefaultHealthCheckPredictionManagerTest {
+
+    @Mock
+    private AtivoHealthHistoryRepository ativoHealthHistoryRepository;
+    @Mock
+    private PredictiveMaintenanceService predictiveMaintenanceService;
+    @Mock
+    private MaintenanceDispatcherService maintenanceDispatcherService;
+
+    @InjectMocks
+    private DefaultHealthCheckPredictionManager manager;
+
+    private Ativo ativo;
+    private List<String> components;
+
+    @BeforeEach
+    void setUp() {
+        ativo = new Ativo();
+        ativo.setId(1L);
+        components = List.of("DISK:SN1");
+    }
+
+    @Test
+    @DisplayName("processPrediction: Deve pular predição se calculada recentemente")
+    void shouldSkipPredictionIfRecentlyCalculated() {
+        // Arrange
+        Map<String, Object> attrs = new java.util.HashMap<>();
+        attrs.put("prediction_calculated_at", LocalDateTime.now().minusHours(1).toString());
+        ativo.setAtributos(attrs);
+
+        // Act
+        manager.processPrediction(ativo, components);
+
+        // Assert
+        verify(ativoHealthHistoryRepository, never()).findByAtivoIdAndComponenteInAndMetricaAndDataRegistroAfterOrderByDataRegistroAsc(
+                anyLong(), anyList(), anyString(), any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("processPrediction: Deve executar predição quando expirada")
+    void shouldExecutePredictionWhenExpired() {
+        // Arrange
+        Map<String, Object> attrs = new java.util.HashMap<>();
+        attrs.put("prediction_calculated_at", LocalDateTime.now().minusHours(25).toString());
+        ativo.setAtributos(attrs);
+
+        when(ativoHealthHistoryRepository.findByAtivoIdAndComponenteInAndMetricaAndDataRegistroAfterOrderByDataRegistroAsc(
+                eq(1L), eq(components), eq("FREE_SPACE_GB"), any(LocalDateTime.class)))
+                .thenReturn(Collections.emptyList());
+
+        // Act
+        manager.processPrediction(ativo, components);
+
+        // Assert
+        verify(ativoHealthHistoryRepository).findByAtivoIdAndComponenteInAndMetricaAndDataRegistroAfterOrderByDataRegistroAsc(
+                eq(1L), eq(components), eq("FREE_SPACE_GB"), any(LocalDateTime.class));
+    }
+
+    @Test
+    @DisplayName("processPrediction: Deve atualizar atributos e despachar manutenção se houver predição válida")
+    void shouldUpdateAttributesAndDispatchMaintenance() {
+        // Arrange
+        AtivoHealthHistory history = new AtivoHealthHistory();
+        history.setComponente("DISK:SN1");
+        List<AtivoHealthHistory> histories = List.of(history);
+
+        when(ativoHealthHistoryRepository.findByAtivoIdAndComponenteInAndMetricaAndDataRegistroAfterOrderByDataRegistroAsc(
+                eq(1L), eq(components), eq("FREE_SPACE_GB"), any(LocalDateTime.class)))
+                .thenReturn(histories);
+
+        LocalDate exhaustionDate = LocalDate.now().plusDays(10);
+        PredictionResult prediction = new PredictionResult(exhaustionDate, -1.0, 100.0, 0L);
+
+        when(predictiveMaintenanceService.predictExhaustionDate(anyList())).thenReturn(prediction);
+
+        // Act
+        manager.processPrediction(ativo, components);
+
+        // Assert
+        verify(predictiveMaintenanceService).predictExhaustionDate(anyList());
+        verify(maintenanceDispatcherService).dispatchIfNecessary(ativo, exhaustionDate);
+
+        // Check if attributes updated (implied by dispatch call with updated object, but hard to assert Map content strictly with mocks unless we inspect arguments)
+        // Simple verification is enough for unit test of flow
+    }
+}


### PR DESCRIPTION
This change extracts the complex predictive maintenance logic from `HealthCheckService` into a dedicated `HealthCheckPredictionManager`. This adheres to the Single Responsibility Principle and improves testability of the prediction workflow.

Key changes:
- Created `HealthCheckPredictionManager` interface and `DefaultHealthCheckPredictionManager` implementation.
- `DefaultHealthCheckPredictionManager` now orchestrates the prediction flow (throttling check -> history fetch -> prediction calculation -> attribute update -> maintenance dispatch).
- `HealthCheckService` was refactored to inject the manager and delegate the task inside `processHealthCheckPayload`.
- `HealthCheckServiceTest` and `HealthCheckServiceBenchmarkTest` were updated to mock the new manager.
- New `DefaultHealthCheckPredictionManagerTest` created to test the isolated logic.


---
*PR created automatically by Jules for task [2123593286985626929](https://jules.google.com/task/2123593286985626929) started by @diogo-rp-menezes*