### PR TITLE
Refactor AtivoController to use IAtivoService and AtivoQueryParams

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/controller/AtivoController.java
+++ b/src/main/java/br/com/aegispatrimonio/controller/AtivoController.java
@@ -5,7 +5,8 @@ import br.com.aegispatrimonio.dto.AtivoDTO;
 import br.com.aegispatrimonio.dto.AtivoHealthHistoryDTO;
 import br.com.aegispatrimonio.dto.AtivoUpdateDTO;
 import br.com.aegispatrimonio.dto.healthcheck.HealthCheckPayloadDTO;
-import br.com.aegispatrimonio.service.AtivoService;
+import br.com.aegispatrimonio.dto.query.AtivoQueryParams;
+import br.com.aegispatrimonio.service.IAtivoService;
 import br.com.aegispatrimonio.service.IHealthCheckService;
 import br.com.aegispatrimonio.service.QRCodeService;
 import jakarta.validation.Valid;
@@ -30,12 +31,12 @@ import java.util.List;
 @Validated
 public class AtivoController {
 
-    private final AtivoService ativoService;
+    private final IAtivoService ativoService;
     private final QRCodeService qrCodeService;
     private final IHealthCheckService healthCheckService;
     private final String frontendUrl;
 
-    public AtivoController(AtivoService ativoService,
+    public AtivoController(IAtivoService ativoService,
                            QRCodeService qrCodeService,
                            IHealthCheckService healthCheckService,
                            @Value("${app.frontend-url}") String frontendUrl) {
@@ -53,16 +54,12 @@ public class AtivoController {
      * @return Uma lista de AtivoDTO representando todos os ativos.
      */
     @GetMapping
-    @PreAuthorize("#filialId == null or @permissionService.hasPermission(authentication, null, 'ATIVO', 'READ', #filialId)")
+    @PreAuthorize("#queryParams.filialId == null or @permissionService.hasPermission(authentication, null, 'ATIVO', 'READ', #queryParams.filialId)")
     public Page<AtivoDTO> listarTodos(
             org.springframework.data.domain.Pageable pageable,
-            @RequestParam(required = false) Long filialId,
-            @RequestParam(required = false) Long tipoAtivoId,
-            @RequestParam(required = false) br.com.aegispatrimonio.model.StatusAtivo status,
-            @RequestParam(required = false) String nome,
-            @RequestParam(required = false) String health
+            @Valid AtivoQueryParams queryParams
     ) {
-        return ativoService.listarTodos(pageable, filialId, tipoAtivoId, status, nome, health);
+        return ativoService.listarTodos(pageable, queryParams);
     }
 
     /**

--- a/src/main/java/br/com/aegispatrimonio/dto/query/AtivoQueryParams.java
+++ b/src/main/java/br/com/aegispatrimonio/dto/query/AtivoQueryParams.java
@@ -1,11 +1,11 @@
 package br.com.aegispatrimonio.dto.query;
 
 import br.com.aegispatrimonio.model.StatusAtivo;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 
 public record AtivoQueryParams(
         Long filialId,
         Long tipoAtivoId,
-        StatusAtivo status
+        StatusAtivo status,
+        String nome,
+        String health
 ) {}

--- a/src/main/java/br/com/aegispatrimonio/service/AtivoService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/AtivoService.java
@@ -6,6 +6,7 @@ import br.com.aegispatrimonio.dto.AtivoDTO;
 import br.com.aegispatrimonio.dto.AtivoNameDTO;
 import br.com.aegispatrimonio.dto.AtivoDetalheHardwareDTO;
 import br.com.aegispatrimonio.dto.AtivoUpdateDTO;
+import br.com.aegispatrimonio.dto.query.AtivoQueryParams;
 import br.com.aegispatrimonio.mapper.AtivoMapper;
 import br.com.aegispatrimonio.model.*;
 import br.com.aegispatrimonio.repository.*;
@@ -28,7 +29,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
-public class AtivoService {
+public class AtivoService implements IAtivoService {
 
     private final AtivoRepository ativoRepository;
     private final AtivoMapper ativoMapper;
@@ -60,15 +61,19 @@ public class AtivoService {
         this.userContextService = userContextService;
     }
 
+    @Override
     @Transactional(readOnly = true)
     public Page<AtivoDTO> listarTodos(org.springframework.data.domain.Pageable pageable,
-                                      Long filialId,
-                                      Long tipoAtivoId,
-                                      StatusAtivo status,
-                                      String nome,
-                                      String health) {
+                                      AtivoQueryParams queryParams) {
         org.springframework.data.domain.Pageable effectivePageable =
                 (pageable == null) ? org.springframework.data.domain.Pageable.unpaged() : pageable;
+
+        Long filialId = queryParams.filialId();
+        Long tipoAtivoId = queryParams.tipoAtivoId();
+        StatusAtivo status = queryParams.status();
+        String nome = queryParams.nome();
+        String health = queryParams.health();
+
         boolean isFuzzySearch = (nome != null && !nome.isBlank());
 
         // Calculate Date Range for Predictive Health
@@ -153,6 +158,7 @@ public class AtivoService {
         }
     }
 
+    @Override
     @Transactional(readOnly = true)
     public AtivoDTO buscarPorId(Long id) {
         Ativo ativo = ativoRepository.findByIdWithDetails(id)
@@ -168,6 +174,7 @@ public class AtivoService {
         return ativoMapper.toDTO(ativo);
     }
 
+    @Override
     @Transactional
     public AtivoDTO criar(AtivoCreateDTO ativoCreateDTO) {
         validarNumeroPatrimonio(ativoCreateDTO.numeroPatrimonio(), null);
@@ -217,6 +224,7 @@ public class AtivoService {
         return ativoMapper.toDTO(ativoCompleto);
     }
 
+    @Override
     @Transactional
     public AtivoDTO atualizar(Long id, AtivoUpdateDTO ativoUpdateDTO) {
         Ativo ativo = ativoRepository.findByIdWithDetails(id)
@@ -280,6 +288,7 @@ public class AtivoService {
         return ativoMapper.toDTO(ativoAtualizado);
     }
 
+    @Override
     @Transactional
     public void deletar(Long id) {
         Ativo ativo = ativoRepository.findById(id)
@@ -296,6 +305,7 @@ public class AtivoService {
         ativoRepository.delete(ativo);
     }
 
+    @Override
     @Transactional(readOnly = true)
     public List<AtivoHealthHistoryDTO> getHealthHistory(Long ativoId) {
         Ativo ativo = ativoRepository.findById(ativoId)

--- a/src/main/java/br/com/aegispatrimonio/service/IAtivoService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/IAtivoService.java
@@ -2,16 +2,19 @@ package br.com.aegispatrimonio.service;
 
 import br.com.aegispatrimonio.dto.AtivoCreateDTO;
 import br.com.aegispatrimonio.dto.AtivoDTO;
+import br.com.aegispatrimonio.dto.AtivoHealthHistoryDTO;
 import br.com.aegispatrimonio.dto.AtivoUpdateDTO;
-import br.com.aegispatrimonio.model.StatusAtivo;
+import br.com.aegispatrimonio.dto.query.AtivoQueryParams;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface IAtivoService {
-    List<AtivoDTO> listarTodos(Pageable pageable, Long filialId, Long tipoAtivoId, StatusAtivo status);
+    Page<AtivoDTO> listarTodos(Pageable pageable, AtivoQueryParams queryParams);
     AtivoDTO buscarPorId(Long id);
     AtivoDTO criar(AtivoCreateDTO ativoCreateDTO);
     AtivoDTO atualizar(Long id, AtivoUpdateDTO ativoUpdateDTO);
     void deletar(Long id);
+    List<AtivoHealthHistoryDTO> getHealthHistory(Long ativoId);
 }

--- a/src/test/java/br/com/aegispatrimonio/service/AtivoServiceTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/AtivoServiceTest.java
@@ -2,6 +2,7 @@ package br.com.aegispatrimonio.service;
 
 import br.com.aegispatrimonio.dto.AtivoCreateDTO;
 import br.com.aegispatrimonio.dto.AtivoUpdateDTO;
+import br.com.aegispatrimonio.dto.query.AtivoQueryParams;
 import br.com.aegispatrimonio.mapper.AtivoMapper;
 import br.com.aegispatrimonio.model.*;
 import br.com.aegispatrimonio.repository.*;
@@ -265,9 +266,10 @@ class AtivoServiceTest {
         when(ativoMapper.toDTO(a3)).thenReturn(dto3);
 
         // Act
+        AtivoQueryParams params = new AtivoQueryParams(null, null, null, query, null);
         org.springframework.data.domain.Page<br.com.aegispatrimonio.dto.AtivoDTO> result = ativoService.listarTodos(
                 org.springframework.data.domain.Pageable.ofSize(10),
-                null, null, null, query, null);
+                params);
 
         // Assert
         verify(searchOptimizationService).rankResults(eq(query), anyList(), any());
@@ -305,9 +307,10 @@ class AtivoServiceTest {
                 .thenReturn(org.springframework.data.domain.Page.empty());
 
         // Act
+        AtivoQueryParams params = new AtivoQueryParams(null, null, null, null, "INDETERMINADO");
         ativoService.listarTodos(
                 org.springframework.data.domain.Pageable.ofSize(10),
-                null, null, null, null, "INDETERMINADO");
+                params);
 
         // Assert
         verify(ativoRepository).findByFilters(any(), any(), any(), any(), isNull(), isNull(), eq(false), any());


### PR DESCRIPTION
Refactored `AtivoController` to depend on `IAtivoService` interface instead of concrete class. Consolidated query parameters in `listarTodos` into `AtivoQueryParams` record, updating Service layer and Tests accordingly. This improves testability and decouples the controller from implementation details.

---
*PR created automatically by Jules for task [4336768348552826846](https://jules.google.com/task/4336768348552826846) started by @diogo-rp-menezes*