### PR TITLE
Fix MySQL Date Overflow in Predictive Maintenance

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/service/PredictiveMaintenanceService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/PredictiveMaintenanceService.java
@@ -67,6 +67,16 @@ public class PredictiveMaintenanceService {
              return null; // Already exhausted in the past (before first record)
         }
 
+        // Cap date at MySQL MAX (9999-12-31) to prevent DataTruncation or runtime errors
+        LocalDate maxDate = LocalDate.of(9999, 12, 31);
+        long maxEpochDay = maxDate.toEpochDay();
+
+        // Check if addition would overflow or exceed max date
+        // maxEpochDay is ~3.6 million, so logic is safe from long overflow unless firstDay is near Long.MAX (impossible)
+        if ((long) daysToZero > (maxEpochDay - firstDay)) {
+            return new PredictionResult(maxDate, beta, alpha, firstDay);
+        }
+
         LocalDate exhaustionDate = LocalDate.ofEpochDay(firstDay + (long) daysToZero);
         return new PredictionResult(exhaustionDate, beta, alpha, firstDay);
     }

--- a/src/test/java/br/com/aegispatrimonio/service/PredictiveMaintenanceServiceTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/PredictiveMaintenanceServiceTest.java
@@ -65,4 +65,26 @@ class PredictiveMaintenanceServiceTest {
         PredictionResult result = service.predictExhaustionDate(history);
         assertNull(result);
     }
+
+    @Test
+    void predictExhaustionDate_ShouldCapDateAtMySQLMax_WhenTrendIsVerySlow() {
+        List<AtivoHealthHistory> history = new ArrayList<>();
+        // Point 1: Today, Value = 100
+        AtivoHealthHistory p1 = new AtivoHealthHistory();
+        p1.setDataRegistro(LocalDateTime.now());
+        p1.setValor(100.0);
+        history.add(p1);
+
+        // Point 2: Tomorrow, Value = 99.99999 (Very slow degradation)
+        // This would result in ~1 billion days to reach zero
+        AtivoHealthHistory p2 = new AtivoHealthHistory();
+        p2.setDataRegistro(LocalDateTime.now().plusDays(1));
+        p2.setValor(99.99999);
+        history.add(p2);
+
+        PredictionResult result = service.predictExhaustionDate(history);
+
+        assertNotNull(result);
+        assertEquals(LocalDate.of(9999, 12, 31), result.exhaustionDate());
+    }
 }


### PR DESCRIPTION
Implemented a safeguard in `PredictiveMaintenanceService` to cap predicted dates at `9999-12-31`. This handles edge cases where very slow disk degradation (near-zero slope) results in predictions millions of years in the future, which previously caused MySQL date overflow errors. Added a unit test to verify the fix and prevent regression.

---
*PR created automatically by Jules for task [17073836397712726159](https://jules.google.com/task/17073836397712726159) started by @diogo-rp-menezes*