### PR TITLE
Fix 404 on login and stabilize backend tests

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/controller/AuthController.java
+++ b/src/main/java/br/com/aegispatrimonio/controller/AuthController.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
  * Fornece um endpoint público para que os usuários possam obter um token JWT.
  */
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping({"/api/v1/auth", "/api/auth"})
 @Slf4j
 public class AuthController {
 

--- a/src/test/java/br/com/aegispatrimonio/security/JwtAuthFilterTest.java
+++ b/src/test/java/br/com/aegispatrimonio/security/JwtAuthFilterTest.java
@@ -69,18 +69,16 @@ class JwtAuthFilterTest extends BaseIT {
     }
 
     @Test
-    @DisplayName("Filtro: Deve lançar UsernameNotFoundException se o usuário do token não for encontrado")
-    void doFilterInternal_usuarioNaoEncontrado_deveLancarExcecao() {
+    @DisplayName("Filtro: Deve retornar 401 Unauthorized se o usuário do token não for encontrado")
+    void doFilterInternal_usuarioNaoEncontrado_deveRetornarUnauthorized() throws Exception {
         String token = "token-for-non-existing-user";
         String email = "non.existing@aegis.com";
 
         when(jwtService.extractUsername(token)).thenReturn(email);
         when(userDetailsService.loadUserByUsername(email)).thenThrow(new UsernameNotFoundException("User not found"));
 
-        // CORREÇÃO: O MockMvc propaga a exceção original do mock, então a verificamos diretamente.
-        assertThrows(UsernameNotFoundException.class, () -> {
-            mockMvc.perform(get("/api/v1/ativos").header("Authorization", "Bearer " + token));
-        });
+        mockMvc.perform(get("/api/v1/ativos").header("Authorization", "Bearer " + token))
+                .andExpect(status().isUnauthorized());
     }
 
     @Test


### PR DESCRIPTION
This commit addresses a 404 Not Found error reported when the frontend attempts to login via `/api/auth/login`. The backend `AuthController` was previously only mapped to `/api/v1/auth`. I have updated the controller to support both `/api/v1/auth` and `/api/auth` to maintain compatibility with the current frontend configuration. Additionally, I updated `JwtAuthFilterTest` to correctly assert that a 401 Unauthorized status is returned (instead of an exception being thrown) when a user is not found, reflecting the actual behavior of the filter chain. Verified by running backend tests.

---
*PR created automatically by Jules for task [16773596312074527228](https://jules.google.com/task/16773596312074527228) started by @diogo-rp-menezes*