### PR TITLE
Fix 500 error in login and optimize AuthController

### DIFF
--- a/src/main/java/br/com/aegispatrimonio/exception/ApplicationControllerAdvice.java
+++ b/src/main/java/br/com/aegispatrimonio/exception/ApplicationControllerAdvice.java
@@ -14,11 +14,15 @@ import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 @RestControllerAdvice
 public class ApplicationControllerAdvice {
+
+    private static final Logger log = LoggerFactory.getLogger(ApplicationControllerAdvice.class);
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
@@ -78,6 +82,13 @@ public class ApplicationControllerAdvice {
     @ResponseStatus(HttpStatus.CONFLICT)
     public ProblemDetail handleResourceConflictException(ResourceConflictException ex, HttpServletRequest request) {
         return buildProblem(HttpStatus.CONFLICT, "Conflict", ex.getMessage(), request);
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ProblemDetail handleAllUncaughtException(Exception ex, HttpServletRequest request) {
+        log.error("Unknown error occurred: ", ex);
+        return buildProblem(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error", "An unexpected error occurred.", request);
     }
 
     private ProblemDetail buildProblem(HttpStatus status, String title, String detail, HttpServletRequest request) {


### PR DESCRIPTION
This PR addresses a reported 500 Internal Server Error during login. The root cause is likely a `LazyInitializationException` (or similar runtime issue) when accessing the `filiais` collection of the `Funcionario` entity outside of a transaction context in the `AuthController`.

Changes:
1.  **Safety**: Added a try-catch block around the `filiais` extraction logic in `AuthController`. If it fails, the login proceeds with an empty list of branches, ensuring the user is not blocked.
2.  **Optimization**: Removed the redundant `userDetailsService.loadUserByUsername()` call in `login()`. The `UserDetails` are now retrieved directly from the fully authenticated `Authentication` object.
3.  **Observability**: Added a catch-all `@ExceptionHandler(Exception.class)` in `ApplicationControllerAdvice` to ensure all unexpected backend errors are logged with stack traces and return a standard `ProblemDetail` JSON response.

This ensures a robust login experience ("fail-open" for secondary data) and better error visibility.

---
*PR created automatically by Jules for task [711952609179247112](https://jules.google.com/task/711952609179247112) started by @diogo-rp-menezes*