### PR TITLE
Standardize Backend Port to 8080

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,7 +28,7 @@ logging.level.br.com.aegispatrimonio=INFO
 logging.level.org.hibernate.SQL=INFO
 logging.level.org.hibernate.type.descriptor.sql.BasicBinder=TRACE
 
-server.port=${SERVER_PORT:8081}
+server.port=${SERVER_PORT:8080}
 
 # Actuator / Micrometer (Prometheus)
 management.endpoints.web.exposure.include=health,info,metrics,prometheus


### PR DESCRIPTION
Standardized the default server port in `application.properties` to 8080. This resolves a configuration mismatch where the frontend (`.env`) and Docker configuration expected 8080, but the backend defaulted to 8081 when running locally via Maven. This ensures the development environment works out-of-the-box.

---
*PR created automatically by Jules for task [5075595362762510387](https://jules.google.com/task/5075595362762510387) started by @diogo-rp-menezes*