### PR TITLE
Eliminate Mocks in Maintenance Workflow

### DIFF
--- a/frontend/src/views/ManutencoesView.vue
+++ b/frontend/src/views/ManutencoesView.vue
@@ -180,11 +180,144 @@
       </div>
     </div>
   </section>
+
+  <!-- Start Modal -->
+  <div v-if="showStartModal" class="modal fade show d-block" tabindex="-1" style="background: rgba(0,0,0,0.5)">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Iniciar Manutenção</h5>
+          <button type="button" class="btn-close" @click="showStartModal = false"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Técnico Responsável</label>
+            <select class="form-select" v-model="selectedTechnicianId">
+              <option value="">Selecione...</option>
+              <option v-for="tech in technicians" :key="tech.id" :value="tech.id">
+                {{ tech.nome }} ({{ tech.matricula }})
+              </option>
+            </select>
+            <div class="form-text">
+               Certifique-se de escolher um técnico da mesma filial.
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" @click="showStartModal = false">Cancelar</button>
+          <button type="button" class="btn btn-primary" @click="confirmStart">Iniciar</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Conclude Modal -->
+  <div v-if="showConcludeModal" class="modal fade show d-block" tabindex="-1" style="background: rgba(0,0,0,0.5)">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Concluir Manutenção</h5>
+          <button type="button" class="btn-close" @click="showConcludeModal = false"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+             <label class="form-label">Descrição do Serviço *</label>
+             <textarea class="form-control" v-model="concludeData.descricaoServico" rows="3" required></textarea>
+          </div>
+          <div class="row">
+            <div class="col-md-6 mb-3">
+              <label class="form-label">Custo Real (R$)</label>
+              <input type="number" class="form-control" v-model="concludeData.custoReal" min="0" step="0.01">
+            </div>
+             <div class="col-md-6 mb-3">
+              <label class="form-label">Tempo Execução (min)</label>
+              <input type="number" class="form-control" v-model="concludeData.tempoExecucao" min="1">
+            </div>
+          </div>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" @click="showConcludeModal = false">Cancelar</button>
+          <button type="button" class="btn btn-success" @click="confirmConclude">Concluir</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Cancel Modal -->
+  <div v-if="showCancelModal" class="modal fade show d-block" tabindex="-1" style="background: rgba(0,0,0,0.5)">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Cancelar Manutenção</h5>
+          <button type="button" class="btn-close" @click="showCancelModal = false"></button>
+        </div>
+        <div class="modal-body">
+          <div class="mb-3">
+            <label class="form-label">Motivo do Cancelamento *</label>
+            <textarea class="form-control" v-model="cancelMotivo" rows="3" required></textarea>
+          </div>
+        </div>
+        <div class="modal-footer">
+           <button type="button" class="btn btn-secondary" @click="showCancelModal = false">Fechar</button>
+           <button type="button" class="btn btn-danger" @click="confirmCancel">Confirmar Cancelamento</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Details Modal -->
+  <div v-if="showDetailsModal && selectedItem" class="modal fade show d-block" tabindex="-1" style="background: rgba(0,0,0,0.5)">
+    <div class="modal-dialog modal-dialog-centered modal-lg">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Detalhes da Manutenção #{{ selectedItem.id }}</h5>
+          <button type="button" class="btn-close" @click="showDetailsModal = false"></button>
+        </div>
+        <div class="modal-body">
+          <dl class="row">
+            <dt class="col-sm-3">Ativo</dt>
+            <dd class="col-sm-9">{{ selectedItem.ativoNome }} ({{ selectedItem.ativoNumeroPatrimonio }})</dd>
+
+            <dt class="col-sm-3">Tipo</dt>
+            <dd class="col-sm-9">{{ selectedItem.tipo }}</dd>
+
+            <dt class="col-sm-3">Status</dt>
+            <dd class="col-sm-9">
+               <span :class="`badge bg-${getStatusColor(selectedItem.status)}`">{{ selectedItem.status }}</span>
+            </dd>
+
+            <dt class="col-sm-3">Solicitante</dt>
+            <dd class="col-sm-9">{{ selectedItem.solicitanteNome }}</dd>
+
+            <dt class="col-sm-3">Data Solicitação</dt>
+            <dd class="col-sm-9">{{ formatDate(selectedItem.dataSolicitacao) }}</dd>
+
+             <dt class="col-sm-3">Problema</dt>
+            <dd class="col-sm-9">{{ selectedItem.descricaoProblema }}</dd>
+
+            <div v-if="selectedItem.tecnicoResponsavelNome">
+               <dt class="col-sm-3">Técnico</dt>
+               <dd class="col-sm-9">{{ selectedItem.tecnicoResponsavelNome }}</dd>
+            </div>
+
+             <div v-if="selectedItem.descricaoServico">
+               <dt class="col-sm-3">Serviço Realizado</dt>
+               <dd class="col-sm-9">{{ selectedItem.descricaoServico }}</dd>
+            </div>
+          </dl>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" @click="showDetailsModal = false">Fechar</button>
+        </div>
+      </div>
+    </div>
+  </div>
 </template>
 
 <script setup>
 import { ref, reactive, onMounted } from 'vue';
 import { manutencaoService } from '../services/manutencaoService';
+import { request } from '../services/api';
 import ManutencaoForm from './ManutencaoForm.vue';
 
 const items = ref([]);
@@ -192,6 +325,26 @@ const loading = ref(false);
 const showForm = ref(false);
 const filterStatus = ref('');
 const editId = ref(null);
+
+// Modal States
+const showStartModal = ref(false);
+const showConcludeModal = ref(false);
+const showDetailsModal = ref(false);
+const showCancelModal = ref(false);
+
+const selectedItem = ref(null);
+
+// Form Data
+const technicians = ref([]);
+const selectedTechnicianId = ref("");
+
+const concludeData = reactive({
+  descricaoServico: "",
+  custoReal: 0,
+  tempoExecucao: 60
+});
+
+const cancelMotivo = ref("");
 
 const pageInfo = reactive({
   page: 0,
@@ -201,6 +354,15 @@ const pageInfo = reactive({
   from: 0,
   to: 0,
 });
+
+async function fetchTechnicians() {
+  try {
+    const response = await request('/funcionarios?role=ROLE_TECNICO&size=100');
+    technicians.value = response.content;
+  } catch (e) {
+    console.error("Erro ao buscar técnicos:", e);
+  }
+}
 
 async function fetchPage(page = 0) {
   loading.value = true;
@@ -272,41 +434,69 @@ async function aprovar(item) {
   }
 }
 
-async function iniciar(item) {
-  // Mock de input técnico ID para MVP (Hardcoded por enquanto ou prompt)
-  const tecnicoId = prompt("ID do Técnico Responsável (deve ser da mesma filial):");
-  if (!tecnicoId) return;
+function iniciar(item) {
+  selectedItem.value = item;
+  selectedTechnicianId.value = "";
+  showStartModal.value = true;
+}
+
+async function confirmStart() {
+  if (!selectedTechnicianId.value) {
+    alert("Selecione um técnico.");
+    return;
+  }
 
   try {
-    await manutencaoService.iniciar(item.id, { tecnicoId: parseInt(tecnicoId) });
+    await manutencaoService.iniciar(selectedItem.value.id, { tecnicoId: parseInt(selectedTechnicianId.value) });
+    showStartModal.value = false;
     fetchPage(pageInfo.page);
   } catch (e) {
     alert('Erro ao iniciar: ' + e.message);
   }
 }
 
-async function concluir(item) {
-  const descricao = prompt("Descrição do Serviço:");
-  if (!descricao) return;
+function concluir(item) {
+  selectedItem.value = item;
+  concludeData.descricaoServico = "";
+  concludeData.custoReal = 0;
+  concludeData.tempoExecucao = 60;
+  showConcludeModal.value = true;
+}
+
+async function confirmConclude() {
+  if (!concludeData.descricaoServico) {
+    alert("Informe a descrição do serviço.");
+    return;
+  }
 
   try {
-    await manutencaoService.concluir(item.id, {
-      descricaoServico: descricao,
-      custoReal: 0, // Simplificação
-      tempoExecucao: 60 // Simplificação
+    await manutencaoService.concluir(selectedItem.value.id, {
+      descricaoServico: concludeData.descricaoServico,
+      custoReal: concludeData.custoReal,
+      tempoExecucao: concludeData.tempoExecucao
     });
+    showConcludeModal.value = false;
     fetchPage(pageInfo.page);
   } catch (e) {
     alert('Erro ao concluir: ' + e.message);
   }
 }
 
-async function cancelar(item) {
-  const motivo = prompt("Motivo do cancelamento:");
-  if (!motivo) return;
+function cancelar(item) {
+  selectedItem.value = item;
+  cancelMotivo.value = "";
+  showCancelModal.value = true;
+}
+
+async function confirmCancel() {
+  if (!cancelMotivo.value) {
+    alert("Informe o motivo.");
+    return;
+  }
 
   try {
-    await manutencaoService.cancelar(item.id, motivo);
+    await manutencaoService.cancelar(selectedItem.value.id, cancelMotivo.value);
+    showCancelModal.value = false;
     fetchPage(pageInfo.page);
   } catch (e) {
     alert('Erro ao cancelar: ' + e.message);
@@ -314,11 +504,13 @@ async function cancelar(item) {
 }
 
 function verDetalhes(item) {
-  alert(`Detalhes da Manutenção #${item.id}\nAtivo: ${item.ativoNome}\nProblema: ${item.descricaoProblema}`);
+  selectedItem.value = item;
+  showDetailsModal.value = true;
 }
 
 onMounted(() => {
   fetchPage(0);
+  fetchTechnicians();
 });
 </script>
 

--- a/src/main/java/br/com/aegispatrimonio/controller/FuncionarioController.java
+++ b/src/main/java/br/com/aegispatrimonio/controller/FuncionarioController.java
@@ -49,8 +49,9 @@ public class FuncionarioController {
     public Page<FuncionarioDTO> listarTodos(
             @Parameter(description = "Nome para filtro") @RequestParam(required = false) String nome,
             @Parameter(description = "ID do departamento para filtro") @RequestParam(required = false) Long departamentoId,
+            @Parameter(description = "Role do usuário para filtro") @RequestParam(required = false) String role,
             @Parameter(hidden = true) Pageable pageable) {
-        return funcionarioService.listarTodos(nome, departamentoId, pageable);
+        return funcionarioService.listarTodos(nome, departamentoId, role, pageable);
     }
 
     @GetMapping("/{id}")

--- a/src/main/java/br/com/aegispatrimonio/service/FuncionarioService.java
+++ b/src/main/java/br/com/aegispatrimonio/service/FuncionarioService.java
@@ -56,7 +56,7 @@ public class FuncionarioService {
     }
 
     @Transactional(readOnly = true)
-    public Page<FuncionarioDTO> listarTodos(String nome, Long departamentoId, Pageable pageable) {
+    public Page<FuncionarioDTO> listarTodos(String nome, Long departamentoId, String role, Pageable pageable) {
         Usuario usuario = currentUserProvider.getCurrentUsuario();
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
 
@@ -71,6 +71,12 @@ public class FuncionarioService {
         if (departamentoId != null) {
             spec = spec.and((root, query, cb) ->
                     cb.equal(root.get("departamento").get("id"), departamentoId)
+            );
+        }
+
+        if (role != null && !role.trim().isEmpty()) {
+            spec = spec.and((root, query, cb) ->
+                    cb.equal(root.join("usuario").get("role"), role)
             );
         }
 

--- a/src/test/java/br/com/aegispatrimonio/service/FuncionarioServiceTest.java
+++ b/src/test/java/br/com/aegispatrimonio/service/FuncionarioServiceTest.java
@@ -97,7 +97,20 @@ class FuncionarioServiceTest {
 
         when(funcionarioRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(page);
 
-        funcionarioService.listarTodos("nome", 1L, pageable);
+        funcionarioService.listarTodos("nome", 1L, null, pageable);
+
+        verify(funcionarioRepository).findAll(any(Specification.class), eq(pageable));
+    }
+
+    @Test
+    @DisplayName("ListarTodos: Deve filtrar por role quando informado")
+    void listarTodos_comRole_deveFiltrar() {
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Funcionario> page = new PageImpl<>(List.of(funcionario));
+
+        when(funcionarioRepository.findAll(any(Specification.class), eq(pageable))).thenReturn(page);
+
+        funcionarioService.listarTodos(null, null, "ROLE_TECNICO", pageable);
 
         verify(funcionarioRepository).findAll(any(Specification.class), eq(pageable));
     }


### PR DESCRIPTION
This PR eliminates the usage of browser native `prompt()` and `alert()` for user input in the Maintenance workflow, replacing them with proper UI Modals.

**Changes:**
- **Backend:**
    - Updated `FuncionarioController` to accept a `role` query parameter.
    - Updated `FuncionarioService` to filter employees by role using JPA Specifications.
    - Added unit tests in `FuncionarioServiceTest`.
- **Frontend:**
    - Modified `ManutencoesView.vue` to include Modals for:
        - **Start Maintenance:** Select a technician from a dropdown (fetched from backend).
        - **Conclude Maintenance:** Input service description, cost, and time.
        - **Cancel Maintenance:** Input reason.
        - **Details:** View full details in a read-only modal.
    - Added `fetchTechnicians` logic to populate the dropdown.
    - Removed hardcoded values and `prompt` usage.

---
*PR created automatically by Jules for task [11180328155519074040](https://jules.google.com/task/11180328155519074040) started by @diogo-rp-menezes*